### PR TITLE
docs(powershell): retarget standards to PowerShell 7.6 LTS

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -39,8 +39,9 @@ All code generation must comply with established PowerShell community best pract
 
 ### Script Development Guidelines
 - **Approved Verbs Only**: Use Microsoft's approved PowerShell verbs (`Get-Verb`) for ALL function names consistently
-- **Version Compatibility**: Maintain compatibility with Windows PowerShell 5.1 unless specific PowerShell 7+ features are required
-- **Version Annotations**: Document any PowerShell 7+ specific features with `#requires -version 7.0` at script header
+- **Version Compatibility**: Default target is **PowerShell 7.6 (LTS)**. Maintain Windows PowerShell 5.1 compatibility only when the project must run on estates without pwsh installed — decide this deliberately, not by habit
+- **Version Annotations**: Declare the target with `#requires -Version 7.6` at the script header. Never emit `#requires -Version 7.0` — PowerShell 7.0–7.3 are retired, and 7.4/7.5 lose support on 10-Nov-2026
+- **Version-Dependent Features**: Before emitting a cmdlet or parameter added in 7.5 or 7.6, confirm the declared target supports it — see [powershell-version.instructions.md](instructions/powershell-version.instructions.md)
 - **Output Standards**: Avoid `Write-Host` except when colored console output is explicitly required
   - Use `Write-Verbose`, `Write-Debug`, `Write-Information`, `Write-Warning`, or `Write-Error` instead
   - Leverage pipeline output for data flow
@@ -48,7 +49,9 @@ All code generation must comply with established PowerShell community best pract
 
 ### Modern PowerShell Features
 - Use `[PSCredential]::new()` instead of `New-Object` for credential creation
-- Leverage PowerShell 5.1+ features when available
+- Use `Install-PSResource` / `Find-PSResource` (Microsoft.PowerShell.PSResourceGet, in-box since 7.4) over PowerShellGet v2 `Install-Module` / `Find-Module`
+- Call `Start-ThreadJob` unqualified — the module was renamed to `Microsoft.PowerShell.ThreadJob` in 7.6, so the old `ThreadJob\` qualifier breaks
+- Leverage current-version features when the declared target allows: `ConvertTo-CliXml`/`ConvertFrom-CliXml`, `ConvertFrom-Json -DateKind`, `Test-Json -IgnoreComments` (7.5+); `Get-Command -ExcludeModule`, `Get-Clipboard -Delimiter` (7.6+)
 - Avoid redundant parameter validation (mandatory parameters are implicitly not null/empty)
 
 ## 🛡️ Security Requirements
@@ -277,22 +280,32 @@ if ($items.Count -lt 100) {
 }
 ```
 
-### Avoid These Anti-Patterns
+### Array Accumulation (version-dependent — read this before flagging `+=`)
 ```powershell
-# ❌ Array appending in loops (creates new array each time)
+# ✅ Best on every version — assign the loop output directly, no per-iteration allocation
+$results = foreach ($item in $collection) {
+    Get-ProcessedItem -Item $item
+}
+
+# ✅ Also good: pipeline output
+$results = $collection | ForEach-Object { Get-ProcessedItem -Item $_ }
+
+# ✅ When accumulation is genuinely conditional, use the generic List
+$results = [System.Collections.Generic.List[object]]::new()
+foreach ($item in $collection) {
+    if (Test-ItemRelevant -Item $item) {
+        $results.Add((Get-ProcessedItem -Item $item))
+    }
+}
+
+# ⚠️ `+=` — O(n²) on Windows PowerShell 5.1 and 7.4, but PowerShell 7.5 optimized it for
+# object arrays, where it now outperforms List<T>.Add(). Flag it only when the declared
+# target includes 5.1/7.4, or when the loop is unbounded on any version.
 $results = @()
-foreach ($item in $collection) {
-    $results += Process-Item $item
-}
+foreach ($item in $collection) { $results += Get-ProcessedItem -Item $item }
 
-# ✅ Use ArrayList or generic collections
+# ❌ Never generate ArrayList — non-generic, boxes values, forces [void] noise on every Add()
 $results = [System.Collections.ArrayList]::new()
-foreach ($item in $collection) {
-    [void]$results.Add((Process-Item $item))
-}
-
-# ✅ Better: Use pipeline when possible
-$results = $collection | ForEach-Object { Process-Item $_ }
 ```
 
 ### Pipeline Optimization (Community Best Practice)
@@ -520,8 +533,10 @@ Describe "Get-ExampleData" -Tag "Unit" {
     Author = 'Jeffrey Stuhr'
     Description = 'Clear description of module purpose and business value'
 
-    PowerShellVersion = '5.1'
-    CompatiblePSEditions = @('Desktop', 'Core')
+    # Target PowerShell 7.6 (LTS) for new modules. Use '5.1' + @('Desktop','Core') only when
+    # the module must run on Windows estates without pwsh installed.
+    PowerShellVersion = '7.6'
+    CompatiblePSEditions = @('Core')
 
     FunctionsToExport = @('Get-Something', 'Set-Something')  # Explicit exports only
     CmdletsToExport = @()
@@ -549,10 +564,11 @@ All generated code must automatically comply with:
 - [ ] **Parameter Validation**: Validate parameters before using in function calls, especially for empty/whitespace values
 - [ ] **Approved Verbs**: Only Microsoft-approved verbs from Get-Verb (consistently in ALL examples)
 - [ ] **String Operations**: Context-appropriate choice between += and StringBuilder
-- [ ] **Modern PowerShell**: Use `[PSCredential]::new()` instead of New-Object
+- [ ] **Modern PowerShell**: Use `[PSCredential]::new()` instead of New-Object; `Install-PSResource` over `Install-Module`
+- [ ] **Version Targeting**: Declared `#requires -Version` / `PowerShellVersion` matches the features actually used, and is 7.6 unless 5.1 support is a stated requirement
 - [ ] **Output Types**: Use descriptive type names or custom classes, not misleading [PSCustomObject]
 - [ ] **Documentation**: Proper comment-based help format with opening `<#` marker
-- [ ] **Performance**: No array appending in large loops, efficient pipeline operations
+- [ ] **Performance**: Loop output assigned directly where possible; no `ArrayList`; `+=` only where the target version makes it safe
 - [ ] **Error Termination**: Use `Write-Error -ErrorAction Stop` instead of bare `throw` when ErrorAction compliance is needed
 
 ## 🔍 Quality Standards

--- a/.github/instructions/cicd.instructions.md
+++ b/.github/instructions/cicd.instructions.md
@@ -15,7 +15,7 @@ First, determine the pipeline requirements:
 
 ### Project Information Needed
 - **Platform Preference**: Azure DevOps, GitHub Actions, GitLab CI, or Jenkins
-- **PowerShell Versions**: Windows PowerShell 5.1, PowerShell 7.x, or both
+- **PowerShell Versions**: PowerShell 7.6 (LTS, default), or 5.1 + 7.6 when Windows PowerShell support is required. Retire 7.4/7.5-only matrices before 10-Nov-2026, when both reach end of support
 - **Target Environments**: Development, Testing, Staging, Production
 - **Deployment Targets**: PowerShell Gallery, internal repositories, or direct deployment
 - **Security Requirements**: Code signing, credential management, compliance scanning

--- a/.github/instructions/module.instructions.md
+++ b/.github/instructions/module.instructions.md
@@ -24,7 +24,7 @@ Collect essential information for module development:
 - **Performance Targets**: Expected load, scalability, and response time requirements
 
 #### Technical Requirements
-- **PowerShell Versions**: Windows PowerShell 5.1, PowerShell 7.x, or both
+- **PowerShell Versions**: PowerShell 7.6 (LTS, default for new modules), or 5.1 + 7.6 when the module must run on Windows estates without pwsh. Do not target 7.4/7.5 alone — both lose support 10-Nov-2026
 - **Platform Support**: Windows, Linux, macOS, or cross-platform
 - **Integration Points**: External APIs, databases, file systems, or services
 - **Deployment Method**: PowerShell Gallery, internal repository, or direct installation
@@ -81,8 +81,10 @@ Generate comprehensive module manifest (ModuleName.psd1):
     Description = 'Comprehensive description of module functionality and business value'
 
     # PowerShell Version Requirements
-    PowerShellVersion = '5.1'
-    CompatiblePSEditions = @('Desktop', 'Core')
+    # Default to 7.6 (LTS). Switch to '5.1' + @('Desktop','Core') only when Windows PowerShell
+    # support is an explicit requirement — see instructions/powershell-version.instructions.md
+    PowerShellVersion = '7.6'
+    CompatiblePSEditions = @('Core')
 
     # Dependencies
     RequiredModules = @(

--- a/.github/instructions/pester-supporting-docs/cicd-integration.md
+++ b/.github/instructions/pester-supporting-docs/cicd-integration.md
@@ -4,6 +4,11 @@ Targets **Pester 6.0+**. Pester 6 supports **Windows PowerShell 5.1** and **Powe
 support for PowerShell 3, 4, 6, and early/unsupported 7.x was removed, so drop `7.2` and `7.3` from
 existing test matrices.
 
+**Matrix targets (verified 2026-08-01):** build against **PowerShell 7.6 (LTS)**. PowerShell 7.4 and
+7.5 both reach end of support on **10-Nov-2026** - keep them in the matrix only while you still
+support consumers on those versions, and plan their removal. See
+[powershell-version.instructions.md](../powershell-version.instructions.md).
+
 **NOTE**: Do not use Unicode emojis in any generated code, documentation, or test output. Use plain
 text descriptions and standard ASCII characters only.
 
@@ -125,9 +130,16 @@ jobs:
     - name: Install Dependencies
       shell: ${{ matrix.shell }}
       run: |
-        Set-PSRepository PSGallery -InstallationPolicy Trusted
-        Install-Module Pester -MinimumVersion $env:PESTER_VERSION -Force -Scope CurrentUser
-        Install-Module PSScriptAnalyzer -Force -Scope CurrentUser
+        # Install-PSResource is in-box on PowerShell 7.4+; Windows PowerShell 5.1 needs PowerShellGet.
+        if (Get-Command Install-PSResource -ErrorAction SilentlyContinue) {
+            Install-PSResource Pester -Version "[$env:PESTER_VERSION,)" -Scope CurrentUser -TrustRepository
+            Install-PSResource PSScriptAnalyzer -Scope CurrentUser -TrustRepository
+        }
+        else {
+            Set-PSRepository PSGallery -InstallationPolicy Trusted
+            Install-Module Pester -MinimumVersion $env:PESTER_VERSION -Force -Scope CurrentUser
+            Install-Module PSScriptAnalyzer -Force -Scope CurrentUser
+        }
 
     - name: Run PSScriptAnalyzer
       shell: ${{ matrix.shell }}
@@ -271,9 +283,16 @@ jobs:
     - name: Install Dependencies
       shell: pwsh
       run: |
-        Set-PSRepository PSGallery -InstallationPolicy Trusted
-        Install-Module Pester -MinimumVersion $env:PESTER_VERSION -Force -Scope CurrentUser
-        Install-Module PSScriptAnalyzer -Force -Scope CurrentUser
+        # Install-PSResource is in-box on PowerShell 7.4+; Windows PowerShell 5.1 needs PowerShellGet.
+        if (Get-Command Install-PSResource -ErrorAction SilentlyContinue) {
+            Install-PSResource Pester -Version "[$env:PESTER_VERSION,)" -Scope CurrentUser -TrustRepository
+            Install-PSResource PSScriptAnalyzer -Scope CurrentUser -TrustRepository
+        }
+        else {
+            Set-PSRepository PSGallery -InstallationPolicy Trusted
+            Install-Module Pester -MinimumVersion $env:PESTER_VERSION -Force -Scope CurrentUser
+            Install-Module PSScriptAnalyzer -Force -Scope CurrentUser
+        }
 
     - name: Run Security Tests
       shell: pwsh
@@ -385,9 +404,12 @@ jobs:
 
 ### GitHub Actions Notes
 
-- `actions/setup-powershell` is not an official action. GitHub-hosted runners ship PowerShell 7.4+
-  preinstalled (`shell: pwsh`), and `windows-latest` also has Windows PowerShell 5.1
-  (`shell: powershell`). Select the shell rather than installing a version.
+- `actions/setup-powershell` is not an official action. GitHub-hosted runners ship a supported
+  PowerShell 7 preinstalled (`shell: pwsh`), and `windows-latest` also has Windows PowerShell 5.1
+  (`shell: powershell`). Select the shell rather than installing a version. If your gate requires a
+  specific release (for example 7.6 for `Join-Path` multi-segment or `Get-Command -ExcludeModule`),
+  assert it rather than assuming the runner image:
+  `if ($PSVersionTable.PSVersion -lt [version]'7.6') { throw "Need PowerShell 7.6+, got $($PSVersionTable.PSVersion)" }`
 - `::set-output` was disabled by GitHub in 2023. Write to `$GITHUB_OUTPUT` instead:
   `"name=value" | Out-File $env:GITHUB_OUTPUT -Append`.
 - `$config.Output.CIFormat = 'GithubActions'` makes Pester emit `::error` and `::warning`
@@ -744,9 +766,14 @@ variables:
 # GitLab needs JUnit for test results and Cobertura for coverage. Pester 6
 # supports both natively - set TestResult.OutputFormat = 'JUnitXml' and
 # CodeCoverage.OutputFormat = 'Cobertura' in PesterConfiguration.CI.psd1.
+#
+# Container images: the `mcr.microsoft.com/powershell` images are DEPRECATED. PowerShell now
+# ships inside the .NET SDK images - `mcr.microsoft.com/dotnet/sdk:10.0` carries PowerShell 7.6
+# (.NET 10 LTS). Microsoft publishes these for development and testing only; build and maintain
+# your own image for production pipelines.
 test:windows:
   stage: test
-  image: mcr.microsoft.com/powershell:lts-windowsservercore-ltsc2019
+  image: mcr.microsoft.com/dotnet/sdk:10.0-windowsservercore-ltsc2022
   <<: *powershell_template
   script:
     - ./Invoke-Tests.ps1 -TestType Unit -Environment CI -CodeCoverage
@@ -763,7 +790,7 @@ test:windows:
 
 test:linux:
   stage: test
-  image: mcr.microsoft.com/powershell:lts-ubuntu-22.04
+  image: mcr.microsoft.com/dotnet/sdk:10.0
   <<: *powershell_template
   script:
     # Parallel is safe here - no coverage on this job
@@ -774,7 +801,7 @@ test:linux:
 
 security:
   stage: security
-  image: mcr.microsoft.com/powershell:lts-windowsservercore-ltsc2019
+  image: mcr.microsoft.com/dotnet/sdk:10.0-windowsservercore-ltsc2022
   <<: *powershell_template
   script:
     - ./Invoke-Tests.ps1 -TestType Security -Environment CI
@@ -782,7 +809,7 @@ security:
 
 deploy:
   stage: deploy
-  image: mcr.microsoft.com/powershell:lts-windowsservercore-ltsc2019
+  image: mcr.microsoft.com/dotnet/sdk:10.0-windowsservercore-ltsc2022
   script:
     - Write-Host "Deploying to PowerShell Gallery..."
   only:

--- a/.github/instructions/powershell-version.instructions.md
+++ b/.github/instructions/powershell-version.instructions.md
@@ -1,0 +1,242 @@
+---
+applyTo: "**/*.ps1,**/*.psm1,**/*.psd1"
+tools: ['codebase', 'githubRepo']
+description: 'PowerShell version baseline, support lifecycle, and version-dependent language/cmdlet features'
+---
+
+# PowerShell Version Baseline
+
+Which PowerShell version to target, and which features are safe to emit at that target.
+Verified against the Microsoft support lifecycle as of **2026-08-01**.
+
+## Support lifecycle
+
+| Version | Type | Released | End of support | Runtime |
+| --- | --- | --- | --- | --- |
+| **7.6** | **LTS - current target** | 18-Mar-2026 | 14-Nov-2028 | .NET 10 |
+| 7.5 | Stable | 23-Jan-2025 | **10-Nov-2026** | .NET 9 |
+| 7.4 | LTS (previous) | 16-Nov-2023 | **10-Nov-2026** | .NET 8 |
+| 5.1 | Windows component | Aug-2016 | Windows lifecycle | .NET Framework 4.x |
+
+Everything below 7.4 is retired and receives no security updates. Never generate code or CI
+matrices targeting PowerShell 6.x, 7.0-7.3.
+
+> **Act on this:** PowerShell 7.4 and 7.5 both go out of support on **10-Nov-2026**. Any project
+> pinned to 7.4 or 7.5 needs a 7.6 upgrade planned now. Recommend 7.6 for all new work.
+
+Windows PowerShell 5.1 is not deprecated - it ships with Windows and is supported under the
+Windows lifecycle - but it receives no new features. Treat it as a compatibility target, never
+as the target you optimize for.
+
+## Choosing a target
+
+Ask which applies before generating code:
+
+- **Cross-version modules** (shipping to unknown estates) - target `5.1` with
+  `CompatiblePSEditions = @('Desktop', 'Core')`. Gate 7.x-only features behind version checks.
+- **Modern-only automation** (containers, CI, greenfield) - target **7.6** with
+  `CompatiblePSEditions = @('Core')`. Do not carry 5.1 compatibility cost for no reason.
+- **Windows-estate tooling** that must run in-box on servers without pwsh installed - target `5.1`.
+
+Declare the target explicitly, at the top of scripts and in the module manifest:
+
+```powershell
+#requires -Version 7.6
+```
+
+```powershell
+@{
+    PowerShellVersion    = '7.6'
+    CompatiblePSEditions = @('Core')
+}
+```
+
+Use `#requires -Version 7.4` only when you have verified the code avoids every 7.5/7.6 feature
+listed below. `#requires -Version 7.0` is obsolete - that version is retired; if you mean "any
+PowerShell 7", the lowest supported floor is `7.4`, and after 10-Nov-2026 it is `7.6`.
+
+## Version-dependent features
+
+Do not emit these unless the declared target supports them.
+
+### PowerShell 7.5+
+
+| Feature | Notes |
+| --- | --- |
+| `ConvertTo-CliXml` / `ConvertFrom-CliXml` | Serialize to CliXml without a temp file. Replaces `Export-Clixml` to a scratch path. |
+| `ConvertFrom-Json -DateKind` | Controls how date strings deserialize (`Local`, `Utc`, `Offset`, `String`). Use `Utc` or `Offset` for audit data. |
+| `Test-Json -IgnoreComments` / `-AllowTrailingCommas` | Validate JSONC-style config without pre-stripping. |
+| `Resolve-Path -Force` / `Convert-Path -Force` | Wildcard resolution that includes hidden files. |
+| `New-Guid -Empty` / `-InputObject` | Empty GUID and string-to-GUID conversion without a cast. |
+| `Get-Process -IncludeUserName` | No longer requires admin. |
+| Error `ConciseView` `RecommendedAction` | Surfaced in error output. |
+
+### PowerShell 7.6+
+
+| Feature | Notes |
+| --- | --- |
+| `Get-Command -ExcludeModule` | Filter discovery without post-filtering the pipeline. |
+| `Register-ArgumentCompleter -NativeFallback` | Register one cover-all completer for native commands. |
+| `Get-Clipboard -Delimiter` | Split clipboard content on read. |
+| `PSForEach()` / `PSWhere()` | Aliases for the `.Foreach()` / `.Where()` intrinsic methods. Prefer these when `.Where()` collides with a LINQ-style method on the piped type. |
+| `PipelineStopToken` on `Cmdlet` | For binary cmdlets - signaled when the pipeline stops. |
+
+### Promoted from experimental (now always on)
+
+Do not tell users to enable these with `Enable-ExperimentalFeature`; they are mainstream.
+
+- **7.5**: `PSCommandNotFoundSuggestion`, `PSCommandWithArgs`, `PSModuleAutoLoadSkipOfflineFiles`
+- **7.6**: `PSFeedbackProvider`, `PSNativeWindowsTildeExpansion`, `PSRedirectToVariable`,
+  `PSSubsystemPluginModel`
+
+`PSRedirectToVariable` means redirection to a variable is now valid syntax in 7.6:
+
+```powershell
+# 7.6+ - capture a stream without a temp file or subexpression
+Get-Item .\missing 2>&1 > variable:capturedErrors
+```
+
+## Breaking changes to code around
+
+These changed behavior in supported versions. Generated code must not depend on the old behavior.
+
+### PowerShell 7.6
+
+- **`ThreadJob` module renamed to `Microsoft.PowerShell.ThreadJob`.** `Start-ThreadJob` itself is
+  unchanged, so only module-qualified calls and manifest dependencies break.
+
+  ```powershell
+  # ❌ Breaks on 7.6
+  ThreadJob\Start-ThreadJob -ScriptBlock { ... }
+  RequiredModules = @(@{ ModuleName = 'ThreadJob'; ModuleVersion = '2.0.3' })
+
+  # ✅
+  Microsoft.PowerShell.ThreadJob\Start-ThreadJob -ScriptBlock { ... }
+  RequiredModules = @(@{ ModuleName = 'Microsoft.PowerShell.ThreadJob'; ModuleVersion = '2.2.0' })
+  ```
+
+  Simplest fix: call `Start-ThreadJob` unqualified and let module autoloading resolve it.
+
+- **`Join-Path -ChildPath` accepts `string[]`.** Multi-segment joins now work in one call, but
+  code that relied on an array argument stringifying into a single segment breaks.
+
+  ```powershell
+  # 7.6+ - one call instead of nesting
+  Join-Path $PSScriptRoot 'Private' 'Helpers' 'Write-Log.ps1'
+  ```
+
+- **`WildcardPattern.Escape` escapes lone backticks correctly.** Code that double-escaped to work
+  around the old bug now over-escapes.
+
+### PowerShell 7.5
+
+- **`ConvertTo-Json` serializes `BigInteger` as a number**, not an object. Consumers expecting the
+  old object shape break.
+- **`Test-Path -OlderThan` and `-NewerThan` both apply** when specified together. Previously
+  `-OlderThan` was silently ignored - a date-range check that appeared to work was not filtering.
+- **`New-FileCatalog -CatalogVersion` defaults to 2.** Pass `-CatalogVersion 1` explicitly if a
+  downstream validator still requires v1.
+- **`Select-String` `LineNumber` is now `ulong`.** Strict-typed downstream assignments to `int`
+  break.
+
+## Array accumulation - version-dependent guidance
+
+This is the most commonly miscited PowerShell performance rule, and it changed in 7.5.
+
+PowerShell 7.5 optimized `+=` on object arrays. It is no longer the pathological case it is in
+5.1 and 7.4 - it is now **faster than `List<T>.Add()`** for that scenario. The blanket advice
+"never use `+=`" is stale for 7.5+.
+
+What did not change: **assigning the loop output directly is still fastest in every version**, by
+a wide margin. Prefer it regardless of target.
+
+```powershell
+# ✅ Best on every version - no per-iteration allocation at all
+$results = foreach ($item in $collection) {
+    Get-ProcessedItem -Item $item
+}
+
+# ✅ Also fine - pipeline output
+$results = $collection | ForEach-Object { Get-ProcessedItem -Item $_ }
+```
+
+When you must accumulate conditionally and cannot assign loop output directly:
+
+```powershell
+# ✅ Portable across 5.1 and 7.x - use the generic List, not ArrayList
+$results = [System.Collections.Generic.List[object]]::new()
+foreach ($item in $collection) {
+    if (Test-ItemRelevant -Item $item) {
+        $results.Add((Get-ProcessedItem -Item $item))
+    }
+}
+```
+
+Rules for generated code:
+
+- Never generate `[System.Collections.ArrayList]`. It is a non-generic .NET 1.1 type kept only for
+  back-compat, it boxes values, and it forces `[void]` noise on every `.Add()`. Use
+  `[System.Collections.Generic.List[object]]` or a typed `List[T]`.
+- Do not flag `+=` as a defect when the declared target is 7.5+ and the collection is small or the
+  loop is not hot. Flag it when the target includes **5.1 or 7.4**, where it remains O(n²).
+- Do flag `+=` in any loop over an unbounded collection, on any version - direct assignment is
+  still the correct pattern.
+
+## Module installation - use PSResourceGet
+
+`Microsoft.PowerShell.PSResourceGet` (v1.2.0 ships in 7.6) is the supported package client.
+PowerShellGet v2 `Install-Module` / `Find-Module` still work via the compatibility layer, but new
+instructions should use the PSResourceGet verbs.
+
+```powershell
+# ✅ Preferred
+Install-PSResource -Name Pester -Scope CurrentUser -TrustRepository
+Find-PSResource -Name PSScriptAnalyzer
+Publish-PSResource -Path ./MyModule -ApiKey $env:NUGET_KEY
+
+# ⚠️ PowerShellGet v2 - still functional, use only when targeting 5.1 without PSResourceGet installed
+Install-Module -Name Pester -Scope CurrentUser -Force -SkipPublisherCheck
+```
+
+On Windows PowerShell 5.1, `Microsoft.PowerShell.PSResourceGet` is not in-box and must be
+installed first with `Install-Module`. Scripts that must bootstrap on both should detect:
+
+```powershell
+if (Get-Command Install-PSResource -ErrorAction SilentlyContinue) {
+    Install-PSResource -Name $Module -Scope CurrentUser -TrustRepository
+}
+else {
+    Install-Module -Name $Module -Scope CurrentUser -Force -SkipPublisherCheck
+}
+```
+
+## Detecting version at runtime
+
+```powershell
+# ✅ Compare the whole version, not just Major - 7.4 and 7.6 both have Major 7
+if ($PSVersionTable.PSVersion -ge [version]'7.6') {
+    # 7.6+ path
+}
+
+# ✅ $IsWindows is undefined on 5.1, which is always Windows
+$onWindows = $PSVersionTable.PSVersion.Major -eq 5 -or $IsWindows
+
+# ❌ Wrong - true on 7.0 through 7.6 alike
+if ($PSVersionTable.PSVersion.Major -ge 7) { }
+```
+
+Report the runtime .NET version when diagnosing platform-specific behavior:
+
+```powershell
+[System.Runtime.InteropServices.RuntimeInformation]::FrameworkDescription
+```
+
+## Tooling versions
+
+| Tool | Current | Notes |
+| --- | --- | --- |
+| PSScriptAnalyzer | 1.25.0 | Released 20-Mar-2026 |
+| Pester | 6.x | See [pester.instructions.md](pester.instructions.md) |
+| Microsoft.PowerShell.PSResourceGet | 1.2.0 | In-box with 7.6 |
+| PSReadLine | 2.4.5 | In-box with 7.6 |
+| Microsoft.PowerShell.ThreadJob | 2.2.0 | In-box with 7.6, renamed from `ThreadJob` |

--- a/.github/instructions/readme.instructions.md
+++ b/.github/instructions/readme.instructions.md
@@ -22,7 +22,7 @@ Gather information needed for complete README generation:
 - **Current Status**: Development phase, version, and maturity level
 
 #### Technical Specifications
-- **PowerShell Versions**: Compatibility with Windows PowerShell 5.1 and PowerShell 7.x
+- **PowerShell Versions**: State the supported range explicitly — PowerShell 7.6 (LTS) is the current target; note Windows PowerShell 5.1 support only if actually tested
 - **Platform Support**: Windows, Linux, macOS, or cross-platform
 - **Installation Methods**: PowerShell Gallery, manual installation, or enterprise deployment
 - **Configuration Requirements**: Environment setup, credentials, and permissions
@@ -76,7 +76,7 @@ Provide immediate value with copy-paste examples:
 
 ```powershell
 # One-line installation and basic usage
-Install-Module ModuleName -Scope CurrentUser
+Install-PSResource ModuleName -Scope CurrentUser -TrustRepository
 Get-ModuleFunction -Parameter "Value" -ExportFormat HTML
 ```
 
@@ -99,8 +99,8 @@ Comprehensive requirements documentation:
 ### System Requirements
 | Component | Minimum | Recommended | Notes |
 |-----------|---------|-------------|-------|
-| **PowerShell** | 5.1 | 7.4+ | Cross-platform support in 7.x |
-| **Operating System** | Windows 10 | Windows Server 2019+ | Linux/macOS supported in PS 7.x |
+| **PowerShell** | 5.1 | 7.6 (LTS) | 7.4/7.5 lose support 10-Nov-2026; cross-platform in 7.x |
+| **Operating System** | Windows 10 | Windows Server 2022+ | Linux/macOS supported in PS 7.x |
 | **Memory** | 2GB RAM | 8GB+ RAM | Depends on dataset size |
 | **Disk Space** | 100MB | 1GB+ | For logs, reports, and temporary files |
 | **Network** | 1 Mbps | 10 Mbps+ | For multi-server environments |
@@ -108,14 +108,17 @@ Comprehensive requirements documentation:
 ### Dependencies
 ```powershell
 # Install required PowerShell modules
-Install-Module PSFramework -Scope CurrentUser
-Install-Module ImportExcel -Scope CurrentUser
+Install-PSResource PSFramework -Scope CurrentUser -TrustRepository
+Install-PSResource ImportExcel -Scope CurrentUser -TrustRepository
 ```
 
 | Module | Version | Purpose | Installation |
 |--------|---------|---------|--------------|
-| **PSFramework** | 1.7.0+ | Structured logging and configuration | `Install-Module PSFramework` |
-| **ImportExcel** | 7.8.0+ | Excel report generation | `Install-Module ImportExcel` |
+| **PSFramework** | 1.7.0+ | Structured logging and configuration | `Install-PSResource PSFramework` |
+| **ImportExcel** | 7.8.0+ | Excel report generation | `Install-PSResource ImportExcel` |
+
+> On Windows PowerShell 5.1, `Install-PSResource` is not in-box — install
+> `Microsoft.PowerShell.PSResourceGet` first, or fall back to `Install-Module`.
 
 ### Permissions & Access
 <details>
@@ -145,7 +148,7 @@ Multiple installation methods with validation:
 ### Method 1: PowerShell Gallery (Recommended)
 ```powershell
 # Install latest stable version
-Install-Module ModuleName -Scope CurrentUser
+Install-PSResource ModuleName -Scope CurrentUser -TrustRepository
 
 # Verify installation
 Get-Module ModuleName -ListAvailable

--- a/.github/prompts/code-analysis.prompt.md
+++ b/.github/prompts/code-analysis.prompt.md
@@ -84,7 +84,7 @@ ${selection}
 **Performance Context:**
 - Data scale: ${input:dataScale:Small (<1K items),Medium (1K-100K),Large (>100K):Medium}
 - Performance target: ${input:target:Optimize for readability,Optimize for speed,Balance both:Balance both}
-- PowerShell version: ${input:psVersion:5.1,7.x:7.x}
+- PowerShell version: ${input:psVersion:7.6,5.1+7.6:7.6}
 - Environment: ${input:environment:Development,Testing,Production:Production}
 
 **Analysis Areas:**
@@ -97,7 +97,7 @@ ${selection}
 
 **2. Collection Handling ✅**
 - Avoid array += in loops for large datasets
-- Use appropriate collection types (ArrayList, List<T>, etc.)
+- Use appropriate collection types — `List<T>` for accumulation, never `ArrayList` (non-generic, boxes values)
 - Pipeline vs foreach performance trade-offs
 - Memory-efficient processing patterns
 

--- a/.github/prompts/new-function.prompt.md
+++ b/.github/prompts/new-function.prompt.md
@@ -15,7 +15,7 @@ Create a PowerShell function with these specifications:
 **Context:**
 - Current file: ${fileBasename}
 - Project: ${workspaceFolderBasename}
-- PowerShell version: ${input:psVersion:5.1,7.x:7.x}
+- PowerShell version: ${input:psVersion:7.6,5.1+7.6:7.6}
 
 **Requirements:**
 - Use modern PowerShell patterns (PSCredential::new(), $_ in catch blocks)

--- a/.github/prompts/optimize-performance.prompt.md
+++ b/.github/prompts/optimize-performance.prompt.md
@@ -9,7 +9,7 @@ Analyze and optimize this PowerShell code from ${fileBasename} in the ${workspac
 **Performance Context:**
 - **Dataset Size**: ${input:datasetSize:Small (<100 items),Medium (100-1000 items),Large (1000+ items)}
 - **Performance Target**: ${input:performanceTarget:Execution time,Memory usage,Throughput,All}
-- **Current Environment**: ${input:environment:PowerShell 5.1,PowerShell 7.x,Cross-platform}
+- **Current Environment**: ${input:environment:PowerShell 7.6,Windows PowerShell 5.1,Cross-platform}
 - **Criticality**: ${input:criticality:Development,Production,Mission-critical}
 
 **Selected Code:**

--- a/.github/workflows/copilot-quality-gates.yml
+++ b/.github/workflows/copilot-quality-gates.yml
@@ -15,13 +15,16 @@ jobs:
       - name: Setup PowerShell
         shell: pwsh
         run: |
-          # Ensure we're using PowerShell 7+
           $PSVersionTable
-          
+          # Pester 6 requires Windows PowerShell 5.1 or PowerShell 7.4+
+          if ($PSVersionTable.PSVersion -lt [version]'7.4') {
+            throw "PowerShell 7.4+ required, runner has $($PSVersionTable.PSVersion)"
+          }
+
       - name: Install Required Modules
         shell: pwsh
         run: |
-          Install-Module PSScriptAnalyzer, Pester -Force -Scope CurrentUser -SkipPublisherCheck
+          Install-PSResource PSScriptAnalyzer, Pester -Scope CurrentUser -TrustRepository
           Import-Module PSScriptAnalyzer, Pester
           
       - name: Validate Copilot Standards Compliance

--- a/.github/workflows/quality-gates-pr.yml
+++ b/.github/workflows/quality-gates-pr.yml
@@ -35,9 +35,9 @@ jobs:
     - name: Setup PowerShell
       shell: pwsh
       run: |
-        # Install required modules
-        Install-Module -Name PSScriptAnalyzer -Force -Scope CurrentUser
-        Install-Module -Name Pester -Force -Scope CurrentUser -SkipPublisherCheck
+        # Install required modules (PSResourceGet is in-box on PowerShell 7.4+)
+        Install-PSResource -Name PSScriptAnalyzer -Scope CurrentUser -TrustRepository
+        Install-PSResource -Name Pester -Scope CurrentUser -TrustRepository
 
         # Display PowerShell version for debugging
         $PSVersionTable | ConvertTo-Json

--- a/Documentation/Examples/Basic-Function-Example.ps1
+++ b/Documentation/Examples/Basic-Function-Example.ps1
@@ -62,7 +62,7 @@
     Last Updated: 2024-01-15
     
     DEPENDENCIES:
-    - Windows PowerShell 5.1+ or PowerShell 7.x
+    - PowerShell 7.6 (LTS) or Windows PowerShell 5.1
     - WinRM enabled on target computers
     - Appropriate permissions on target systems
     

--- a/Documentation/Examples/Configuration/DefaultConfiguration.psd1
+++ b/Documentation/Examples/Configuration/DefaultConfiguration.psd1
@@ -60,7 +60,9 @@
     Performance = @{
         # String operation thresholds (expert feedback integration)
         StringConcatenationThreshold = 100  # Use StringBuilder above this
-        ArrayAppendThreshold = 50           # Use ArrayList above this
+        # Above this, use direct loop assignment or List[T] - never ArrayList.
+        # On PowerShell 7.5+, += on object arrays is optimized and this threshold can be relaxed.
+        ArrayAppendThreshold = 50
 
         # Memory management
         MaxMemoryUsageMB = 512

--- a/Documentation/Examples/ExampleModule.psd1
+++ b/Documentation/Examples/ExampleModule.psd1
@@ -11,6 +11,9 @@
     Description = 'Example enterprise PowerShell module demonstrating best practices for data processing, user management, and system administration with comprehensive security and compliance features.'
 
     # PowerShell Requirements
+    # This example deliberately demonstrates the cross-version target (Windows PowerShell 5.1 +
+    # PowerShell 7.x). New modules should default to PowerShellVersion = '7.6' with
+    # CompatiblePSEditions = @('Core') - see Templates/Powershell-Module/ModuleName.psd1
     PowerShellVersion = '5.1'
     CompatiblePSEditions = @('Desktop', 'Core')
 

--- a/Documentation/Examples/ExampleModule.psm1
+++ b/Documentation/Examples/ExampleModule.psm1
@@ -19,8 +19,9 @@
 Write-Verbose "Loading Enterprise PowerShell Module: $($MyInvocation.MyCommand.Name)"
 
 # Expert feedback: Get module version from manifest if needed (use $MyInvocation, not hardcoded strings)
-if ($PSVersionTable.PSVersion.Major -ge 7) {
-    Write-Verbose "PowerShell 7+ detected - enhanced features available"
+# Compare the full version, not just Major - 7.4 and 7.6 both report Major 7
+if ($PSVersionTable.PSVersion -ge [version]'7.6') {
+    Write-Verbose "PowerShell 7.6+ detected - current LTS feature set available"
 }
 
 #region Private Functions

--- a/Documentation/Examples/README.md
+++ b/Documentation/Examples/README.md
@@ -9,13 +9,13 @@ ExampleModule demonstrates enterprise-grade PowerShell development following est
 - ✅ **Performance Monitoring**: System performance metrics and alerting
 - ✅ **Configuration Management**: Environment-specific settings and baselines
 - ✅ **Correlation Tracking**: End-to-end operation tracking for troubleshooting
-- ✅ **Modern PowerShell**: Compatible with PowerShell 5.1+ and PowerShell 7+
+- ✅ **Modern PowerShell**: Compatible with Windows PowerShell 5.1 and PowerShell 7.6 (LTS)
 
 ## Installation
 
 ### From PowerShell Gallery
 ```powershell
-Install-Module -Name ExampleModule -Repository PSGallery -Scope CurrentUser
+Install-PSResource -Name ExampleModule -Repository PSGallery -Scope CurrentUser -TrustRepository
 ```
 
 ### From Source

--- a/Documentation/Implementation-Guide.md
+++ b/Documentation/Implementation-Guide.md
@@ -5,7 +5,7 @@
 ### Prerequisites
 - GitHub Copilot subscription
 - VS Code with GitHub Copilot extension
-- PowerShell 5.1+ or PowerShell 7.x
+- PowerShell 7.6 (LTS) recommended; Windows PowerShell 5.1 supported for legacy estates
 - Git for version control
 
 ### Step 1: Enable Copilot Instructions in VS Code

--- a/Documentation/PowerShell-Best-Practices.md
+++ b/Documentation/PowerShell-Best-Practices.md
@@ -273,21 +273,39 @@ function Get-EnterpriseData {
 
 ### Collection Operations ✅
 ```powershell
-# ✅ For small collections (< 1000 items), simple approaches work fine
-$results = @()
-foreach ($item in $smallCollection) {
-    $results += Process-Item $item  # Acceptable for small collections
+# ✅ Best on every version: assign the loop output directly - zero per-iteration allocation
+$results = foreach ($item in $collection) {
+    Get-ProcessedItem -Item $item
 }
 
-# ✅ For large collections, use efficient approaches
+# ✅ Also good: pipeline output
+$results = $collection | ForEach-Object { Get-ProcessedItem -Item $_ }
+
+# ✅ When accumulation is genuinely conditional, use the generic List
 $results = [System.Collections.Generic.List[object]]::new()
 foreach ($item in $largeCollection) {
-    $results.Add((Process-Item $item))
+    if (Test-ItemRelevant -Item $item) {
+        $results.Add((Get-ProcessedItem -Item $item))
+    }
 }
 
-# ✅ Best: Use pipeline when possible
-$results = $collection | ForEach-Object { Process-Item $_ }
+# ⚠️ `+=` is version-dependent, not universally bad
+$results = @()
+foreach ($item in $smallCollection) { $results += Get-ProcessedItem -Item $item }
 ```
+
+**The `+=` rule changed in PowerShell 7.5.** PowerShell 7.5 optimized `+=` on object arrays; it
+now outperforms `List<T>.Add()` for that case. On Windows PowerShell 5.1 and PowerShell 7.4 it
+remains O(n²) and collapses on large collections.
+
+| Target | `+=` verdict |
+|--------|--------------|
+| 7.5+ | Fine for small and mid-size collections; still avoid in unbounded loops |
+| 5.1 / 7.4 | Avoid beyond a few hundred items |
+| Any | Direct loop assignment is always faster - prefer it |
+
+Do not generate `[System.Collections.ArrayList]`. It is a non-generic .NET 1.1 type that boxes
+values and forces `[void]` noise on every `.Add()`. Use `[System.Collections.Generic.List[T]]`.
 
 ### String Building - Context Matters
 ```powershell

--- a/README.md
+++ b/README.md
@@ -4,10 +4,16 @@
 [![BlueSky](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fpublic.api.bsky.app%2Fxrpc%2Fapp.bsky.actor.getProfile%2F%3Factor%3Dtechbyjeff.net&query=%24.followersCount&style=social&logo=bluesky&label=Follow%20on%20BSky)](https://bsky.app/profile/techbyjeff.net)
 [![Blog](https://img.shields.io/badge/Read_My_Blog-TechbyJeff-lightgrey?style=flat-square&logo=ghost)](https://techbyjeff.net)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![PowerShell](https://img.shields.io/badge/PowerShell-5.1%2B-blue.svg)](https://github.com/PowerShell/PowerShell)
+[![PowerShell](https://img.shields.io/badge/PowerShell-7.6_LTS-blue.svg)](https://github.com/PowerShell/PowerShell)
 [![GitHub Copilot](https://img.shields.io/badge/GitHub%20Copilot-Optimized-green.svg)](https://github.com/features/copilot)
 
 Enterprise-grade PowerShell development standards and GitHub Copilot instructions for consistent, secure, and high-quality PowerShell code across teams and projects.
+
+> **Target versions** (verified 2026-08-01): **PowerShell 7.6 (LTS)** is the default target,
+> supported through 14-Nov-2028. Windows PowerShell 5.1 remains supported as a compatibility
+> target. **PowerShell 7.4 and 7.5 both reach end of support on 10-Nov-2026** — plan upgrades now.
+> See [powershell-version.instructions.md](.github/instructions/powershell-version.instructions.md)
+> for the full lifecycle table, version-gated features, and breaking changes.
 
 ## 🚀 Quick Start
 
@@ -79,6 +85,7 @@ PowerShell-Copilot-Standards/
 ├── .github/
 │   ├── copilot-instructions.md      # Main Copilot instructions
 │   ├── instructions/                # Detailed instruction files
+│   │   └── powershell-version.instructions.md  # Version baseline & lifecycle
 │   ├── prompts/                     # Quick-access prompts
 │   └── workflows/                   # CI/CD templates
 ├── Documentation/                   # Reference materials

--- a/Templates/Powershell-Module/ModuleName.psd1
+++ b/Templates/Powershell-Module/ModuleName.psd1
@@ -11,8 +11,10 @@
     Description = 'Enterprise PowerShell module providing [specific business functionality] with comprehensive security and compliance features.'
 
     # PowerShell Requirements
-    PowerShellVersion = '5.1'  # Minimum supported version
-    CompatiblePSEditions = @('Desktop', 'Core')  # Support both Windows PowerShell and PowerShell Core
+    # 7.6 is the current LTS (supported to 14-Nov-2028). 7.4 and 7.5 both end support 10-Nov-2026.
+    # For Windows PowerShell compatibility instead, use: '5.1' with @('Desktop', 'Core')
+    PowerShellVersion = '7.6'  # Minimum supported version
+    CompatiblePSEditions = @('Core')
 
     # Architecture Requirements (if needed)
     # ProcessorArchitecture = 'None'  # None, X86, Amd64, IA64

--- a/Templates/Powershell-Module/README.md
+++ b/Templates/Powershell-Module/README.md
@@ -26,7 +26,7 @@ Get-TemplateFunction -Name "ExampleItem"
 
 ## 📋 Prerequisites
 
-- PowerShell 5.1+ or PowerShell 7.x
+- PowerShell 7.6 (LTS) — or Windows PowerShell 5.1 if the manifest is configured for it
 - Required modules: PSFramework
 - Appropriate permissions for target operations
 

--- a/Tools/Install-CopilotStandards.ps1
+++ b/Tools/Install-CopilotStandards.ps1
@@ -31,7 +31,7 @@
     Version: 1.0.0
 
     REQUIREMENTS:
-    - PowerShell 5.1+ or PowerShell 7.x
+    - PowerShell 7.6 (LTS) or Windows PowerShell 5.1
     - Write permissions to target directory
     - For Symlink: Administrator privileges (Windows)
 #>

--- a/Tools/Test-StandardsCompliance.ps1
+++ b/Tools/Test-StandardsCompliance.ps1
@@ -38,8 +38,8 @@
     Version: 1.0.0
     
     REQUIREMENTS:
-    - PSScriptAnalyzer module
-    - PowerShell 5.1+ or PowerShell 7.x
+    - PSScriptAnalyzer module (1.25.0+)
+    - PowerShell 7.6 (LTS) or Windows PowerShell 5.1
 #>
 
 [CmdletBinding()]
@@ -75,7 +75,13 @@ begin {
         if (-not (Get-Module $module -ListAvailable)) {
             Write-Warning "$module not found. Installing..."
             try {
-                Install-Module $module -Scope CurrentUser -Force -SkipPublisherCheck
+                # Install-PSResource is in-box on PowerShell 7.4+; 5.1 falls back to PowerShellGet
+                if (Get-Command Install-PSResource -ErrorAction SilentlyContinue) {
+                    Install-PSResource $module -Scope CurrentUser -TrustRepository
+                }
+                else {
+                    Install-Module $module -Scope CurrentUser -Force -SkipPublisherCheck
+                }
                 Write-Information "Installed $module" -InformationAction Continue
             }
             catch {
@@ -248,18 +254,41 @@ process {
                         }
                         
                         # Performance checks
-                        if ($content -match '\$\w+\s*\+=\s*.*\$\w+') {
+                        # PowerShell 7.5 optimized `+=` on object arrays - it now outperforms
+                        # List<T>.Add(). Only flag this when the file declares a target that
+                        # still pays the O(n^2) cost (Windows PowerShell 5.1 or PowerShell 7.4).
+                        $targetsLegacyArrayAppend = $true
+                        if ($content -match '(?im)^\s*#requires\s+-Version\s+(\d+\.\d+)') {
+                            $targetsLegacyArrayAppend = [version]$Matches[1] -lt [version]'7.5'
+                        }
+
+                        if ($targetsLegacyArrayAppend -and $content -match '\$\w+\s*\+=\s*.*\$\w+') {
                             $perfIssue = [PSCustomObject]@{
                                 Type = 'ArrayAppending'
                                 File = $file.Name
                                 FilePath = $file.FullName
-                                Message = 'Potential array appending performance issue detected'
+                                Message = 'Array appending detected in a file targeting PowerShell 5.1/7.4, where += is O(n^2)'
                                 Severity = 'Medium'
-                                Recommendation = 'Use pipeline output or ArrayList instead of array appending'
+                                Recommendation = 'Assign the loop output directly ($x = foreach (...) { ... }), or use [System.Collections.Generic.List[object]]. Not ArrayList. On PowerShell 7.5+, += is no longer a performance defect.'
                             }
                             $results.PerformanceIssues += $perfIssue
                             $fileResult.Issues += $perfIssue
                             $results.MediumIssues++
+                        }
+
+                        # ArrayList is a non-generic .NET 1.1 type - flag on every version
+                        if ($content -match '\[System\.Collections\.ArrayList\]|New-Object\s+System\.Collections\.ArrayList') {
+                            $arrayListIssue = [PSCustomObject]@{
+                                Type = 'LegacyCollectionType'
+                                File = $file.Name
+                                FilePath = $file.FullName
+                                Message = 'ArrayList used instead of a generic collection'
+                                Severity = 'Low'
+                                Recommendation = 'Use [System.Collections.Generic.List[object]] or a typed List[T]. ArrayList boxes values and forces [void] on every Add().'
+                            }
+                            $results.PerformanceIssues += $arrayListIssue
+                            $fileResult.Issues += $arrayListIssue
+                            $results.LowIssues++
                         }
                     }
                 }


### PR DESCRIPTION
Retargets the standards to PowerShell 7.6 (LTS).

## Why

The repository's baseline was written approximately a year ago and specified "PowerShell 5.1+ / 7.4+"
throughout. That now points at versions nearing end of support:

- PowerShell 7.4 (LTS) and 7.5 both reach end of support on **10-Nov-2026**.
- PowerShell 7.6 is the current LTS: GA 18-Mar-2026, built on .NET 10, supported through 14-Nov-2028.

Beyond the dates, three pieces of guidance were incorrect rather than merely dated.

## Corrections

### The `+=` performance rule changed in PowerShell 7.5

The standards instructed Copilot never to use `+=` for array accumulation and to prefer `ArrayList`.
PowerShell 7.5 optimised `+=` on object arrays; per Microsoft's published benchmarks it now
outperforms `List<T>.Add()`. The rule is wrong for 7.5+, and remains correct for Windows PowerShell
5.1 and 7.4, where `+=` is still O(n²).

Guidance is now version-conditional:

| Target | Verdict |
|--------|---------|
| 7.5+ | Acceptable for small and mid-size collections; still avoid in unbounded loops |
| 5.1 / 7.4 | Avoid beyond a few hundred items |
| Any | Direct loop assignment (`$x = foreach (...) { }`) is fastest |

`ArrayList` recommendations were removed throughout: it is a non-generic .NET 1.1 type that boxes
values and requires `[void]` on every `.Add()`.

This required a logic change, not only wording. `Tools/Test-StandardsCompliance.ps1` emitted the
stale advice as a rule — flagging every `+=` and recommending `ArrayList` as the remedy. It now
parses a file's `#requires -Version` and flags `+=` only when the declared target still incurs the
O(n²) cost. Verified: no `#requires` flags, 5.1 flags, 7.4 flags, 7.6 does not.

### `ThreadJob` renamed in 7.6

The module is now `Microsoft.PowerShell.ThreadJob`. `Start-ThreadJob` itself is unchanged, so only
module-qualified calls and manifest dependencies break. Guidance now recommends calling it unqualified
and letting autoloading resolve it.

### PowerShell container images are deprecated

`mcr.microsoft.com/powershell` images are marked deprecated in MCR; PowerShell now ships inside the
.NET SDK images. The GitLab CI examples used `lts-ubuntu-22.04`, whose PowerShell support ended
2024-09-30. Replaced with `mcr.microsoft.com/dotnet/sdk:10.0` (PowerShell 7.6 / .NET 10 LTS), noting
that Microsoft publishes these for development and testing and that production pipelines should build
their own image.

## Package client

`Microsoft.PowerShell.PSResourceGet` (v1.2.0, in-box since 7.4) is the supported client. PowerShellGet
v2 remains functional via the compatibility layer, so examples that must bootstrap on 5.1 use a
capability check rather than assuming either:

```powershell
if (Get-Command Install-PSResource -ErrorAction SilentlyContinue) {
    Install-PSResource -Name $Module -Scope CurrentUser -TrustRepository
}
else {
    Install-Module -Name $Module -Scope CurrentUser -Force -SkipPublisherCheck
}
```

The repository's own CI workflows were updated to match, so the standards and their enforcement do not
contradict each other.

## New reference document

`.github/instructions/powershell-version.instructions.md` is the single source for the lifecycle table,
target selection, version-gated features (7.5's `ConvertTo-CliXml`, `ConvertFrom-Json -DateKind`,
`Test-Json -IgnoreComments`; 7.6's `Get-Command -ExcludeModule`,
`Register-ArgumentCompleter -NativeFallback`, `Get-Clipboard -Delimiter`), experimental features
promoted to mainstream, and the breaking changes above. Other instruction files link to it rather than
restating version facts.

It also corrects a runtime-detection anti-pattern present in the examples:

```powershell
# Incorrect - true on 7.0 through 7.6 alike
if ($PSVersionTable.PSVersion.Major -ge 7) { }

# Correct - compare the whole version
if ($PSVersionTable.PSVersion -ge [version]'7.6') { }
```

## Decisions taken

- The module template now defaults to `PowerShellVersion = '7.6'` / `CompatiblePSEditions = @('Core')`.
  Rationale: new modules should not inherit 5.1 compatibility cost by default; it should be a
  deliberate choice.
- `Documentation/Examples/ExampleModule.psd1` deliberately remains at 5.1 / `@('Desktop','Core')` as
  the cross-version demonstration, with a comment recording that.

Windows PowerShell 5.1 is not deprecated anywhere in this change. It is reframed from the default
baseline to a compatibility target that is opted into.

## Verification

- All modified `.ps1`/`.psm1` files parse cleanly (`[Parser]::ParseFile`).
- All modified `.psd1` manifests load cleanly (`Import-PowerShellDataFile`).
- The `#requires`-aware `+=` gating logic was tested against four cases.
- `Install-PSResource` syntax verified against PowerShell 7.6.4 / PSResourceGet 1.2.0.
- markdownlint was not run locally (Node unavailable in the authoring environment); CI covers it.

Version facts verified 2026-08-01 against the [PowerShell support lifecycle](https://learn.microsoft.com/en-us/powershell/scripting/install/powershell-support-lifecycle),
[What's New in 7.6](https://learn.microsoft.com/en-us/powershell/scripting/whats-new/what-s-new-in-powershell-76),
[What's New in 7.5](https://learn.microsoft.com/en-us/powershell/scripting/whats-new/what-s-new-in-powershell-75),
and [Use PowerShell in Docker](https://learn.microsoft.com/en-us/powershell/scripting/install/powershell-in-docker).
