### PR TITLE
fix: make the quality gate able to fail, and fix the 24 tests it hid

### DIFF
--- a/.github/workflows/quality-gates-pr.yml
+++ b/.github/workflows/quality-gates-pr.yml
@@ -163,17 +163,43 @@ jobs:
 
                 $pesterConfig = New-PesterConfiguration
                 $pesterConfig.Run.Exit = $false
+                # Required - without PassThru, Invoke-Pester returns nothing and every
+                # check below silently evaluates against $null.
+                $pesterConfig.Run.PassThru = $true
                 $pesterConfig.Output.Verbosity = 'Detailed'
                 $pesterConfig.CodeCoverage.Enabled = $true
                 $pesterConfig.CodeCoverage.Path = $productionFiles.FullName
 
                 $pesterResults = Invoke-Pester -Configuration $pesterConfig
 
-                if ($pesterResults.Failed -gt 0) {
-                    Write-Host "❌ Pester Tests Failed: $($pesterResults.Failed) of $($pesterResults.Total)" -ForegroundColor Red
-                    $criticalIssues += $pesterResults.Failed
-                } else {
-                    Write-Host "✅ All Pester tests passed: $($pesterResults.Passed) of $($pesterResults.Total)" -ForegroundColor Green
+                # Pester sets $LASTEXITCODE to the failure count. GitHub's pwsh wrapper
+                # exits with it, which would fail the step regardless of the logic below.
+                # Failures are accounted for through $criticalIssues instead.
+                $global:LASTEXITCODE = 0
+
+                if ($null -eq $pesterResults) {
+                    Write-Host "❌ Pester returned no result object - treating as failure" -ForegroundColor Red
+                    $criticalIssues += 1
+                }
+                else {
+                    # Use the *Count properties. $pesterResults.Failed is a collection of
+                    # test objects, so "-gt 0" compares objects to an int, errors as
+                    # non-IComparable, yields empty, and reads as false - which is why
+                    # this gate reported success against 24 failing tests.
+                    if ($pesterResults.FailedCount -gt 0) {
+                        Write-Host "❌ Pester Tests Failed: $($pesterResults.FailedCount) of $($pesterResults.TotalCount)" -ForegroundColor Red
+                        $criticalIssues += $pesterResults.FailedCount
+                    }
+                    else {
+                        Write-Host "✅ All Pester tests passed: $($pesterResults.PassedCount) of $($pesterResults.TotalCount)" -ForegroundColor Green
+                    }
+
+                    # A file that fails discovery contributes zero failed tests, so
+                    # FailedCount alone can report green on a suite that never ran.
+                    if ($pesterResults.FailedContainersCount -gt 0) {
+                        Write-Host "❌ Pester containers failed discovery: $($pesterResults.FailedContainersCount)" -ForegroundColor Red
+                        $criticalIssues += $pesterResults.FailedContainersCount
+                    }
                 }
 
                 if ($pesterResults.CodeCoverage) {

--- a/Documentation/Examples/Test-QualityGates.Tests.ps1
+++ b/Documentation/Examples/Test-QualityGates.Tests.ps1
@@ -12,11 +12,34 @@ BeforeAll {
     if (Test-Path $TestFilePath) {
         . $TestFilePath
     }
+
+    # Test-QualityGates calls Get-ADUser, which ships with RSAT and is absent on CI
+    # runners and non-Windows hosts. Pester cannot mock a command that does not
+    # exist, so define a stub for Mock to replace. Every test that exercises the
+    # function must mock it - otherwise the stub returns nothing and the function's
+    # own "User not found" guard fires.
+    if (-not (Get-Command Get-ADUser -ErrorAction SilentlyContinue)) {
+        function Get-ADUser {
+            [CmdletBinding()]
+            param(
+                [Parameter(Mandatory)] $Identity,
+                [Parameter()] $Properties,
+                [Parameter()] $Server
+            )
+        }
+    }
 }
 
 Describe "Test-QualityGates Function" -Tag "Unit", "QualityDemo" {
 
     Context "Parameter Validation" {
+        BeforeEach {
+            # Without this the stub returns $null and the function throws "User not found"
+            Mock Get-ADUser {
+                [PSCustomObject]@{ Name = 'Test User'; SamAccountName = 'testuser'; Enabled = $true }
+            }
+        }
+
         It "Should accept valid UserName parameter" {
             { Test-QualityGates -UserName "testuser" } | Should -Not -Throw
         }
@@ -100,16 +123,21 @@ Describe "Get-TestResults Function" -Tag "Unit", "GoodExample" {
         }
 
         It "Should handle empty test name appropriately" {
-            { Get-TestResults -TestName "" } | Should -Throw "*cannot be empty*"
+            # A Mandatory [string] rejects '' during binding, before the body runs,
+            # so the message comes from PowerShell - not the function's own guard.
+            { Get-TestResults -TestName "" } | Should -Throw "*empty string*"
         }
 
         It "Should handle whitespace-only test name" {
-            { Get-TestResults -TestName "   " } | Should -Throw "*cannot be empty*"
+            # Whitespace binds fine, so the function's own validation produces this one
+            { Get-TestResults -TestName "   " } | Should -Throw "*cannot be empty or whitespace*"
         }
 
         It "Should return properly typed result" {
             $result = Get-TestResults -TestName "TypeTest"
-            $result.PSTypeName | Should -Be "TestResult"
+            # PSTypeName is consumed when constructing the object; it sets the type
+            # name rather than remaining as a readable property.
+            $result.PSObject.TypeNames[0] | Should -Be "TestResult"
             $result.Status | Should -Be "Passed"
         }
 

--- a/Documentation/Examples/Test-QualityGates.ps1
+++ b/Documentation/Examples/Test-QualityGates.ps1
@@ -153,7 +153,9 @@ function Get-TestResults {
     TestResult. Returns test execution results.
     #>
     [CmdletBinding()]
-    [OutputType([TestResult])]  # Descriptive type name
+    # Descriptive type name. Quoted: 'TestResult' is the PSTypeName applied to the
+    # output object below, not a .NET type - [OutputType([TestResult])] fails to resolve.
+    [OutputType('TestResult')]
     param(
         [Parameter(Mandatory)]  # No redundant ValidateNotNullOrEmpty
         [string]$TestName,

--- a/Documentation/Examples/Testing-Examples/Basic-Function.Tests.ps1
+++ b/Documentation/Examples/Testing-Examples/Basic-Function.Tests.ps1
@@ -7,7 +7,57 @@ BeforeAll {
 }
 
 Describe "Get-BasicServerInfo" -Tag "Unit", "Example" {
-    
+
+    # Default mocks live at Describe level so every Context is hermetic - no test
+    # reaches a real network. Contexts below override individual mocks as needed.
+    #
+    # -RemoveParameterType CimSession is required: PowerShell binds parameters using
+    # the *original* command's metadata even when a command is mocked, so passing a
+    # PSCustomObject stub to -CimSession fails type coercion before the mock body runs.
+    BeforeEach {
+        Mock Test-Connection { $true }
+
+        Mock New-CimSession { [PSCustomObject]@{ ComputerName = $ComputerName } }
+
+        Mock Remove-CimSession -RemoveParameterType CimSession -MockWith { }
+
+        Mock Get-CimInstance -RemoveParameterType CimSession -MockWith {
+            switch ($ClassName) {
+                'Win32_OperatingSystem' {
+                    [PSCustomObject]@{
+                        Caption                 = 'Microsoft Windows Server 2019'
+                        Version                 = '10.0.17763'
+                        ServicePackMajorVersion = 0
+                        OSArchitecture          = '64-bit'
+                        LastBootUpTime          = (Get-Date).AddDays(-5)
+                    }
+                }
+                'Win32_ComputerSystem' {
+                    [PSCustomObject]@{
+                        TotalPhysicalMemory = 17179869184  # 16 GB
+                        Manufacturer        = 'Dell Inc.'
+                        Model               = 'PowerEdge R740'
+                        Domain              = 'contoso.com'
+                        Workgroup           = $null
+                    }
+                }
+                'Win32_Processor' {
+                    [PSCustomObject]@{
+                        Name                      = 'Intel(R) Xeon(R) Gold 6248 CPU @ 2.50GHz'
+                        NumberOfCores             = 8
+                        NumberOfLogicalProcessors = 16
+                    }
+                }
+                'Win32_Service' {
+                    @(
+                        [PSCustomObject]@{ Name = 'Spooler'; DisplayName = 'Print Spooler'; StartMode = 'Auto'; State = 'Running' }
+                        [PSCustomObject]@{ Name = 'Themes'; DisplayName = 'Themes'; StartMode = 'Auto'; State = 'Running' }
+                    )
+                }
+            }
+        }
+    }
+
     Context "Parameter Validation" {
         It "Should accept valid computer names: <TestCase>" -TestCases @(
             @{ ComputerName = 'SERVER01'; Expected = $true }
@@ -20,10 +70,13 @@ Describe "Get-BasicServerInfo" -Tag "Unit", "Example" {
             { Get-BasicServerInfo -ComputerName $ComputerName -WhatIf } | Should -Not -Throw
         }
         
+        # Expected messages are the ones PowerShell's validation attributes actually
+        # emit. ValidatePattern/ValidateLength do not produce friendly text; asserting
+        # invented wording here is what let these tests rot unnoticed.
         It "Should reject invalid computer names: <InvalidName>" -TestCases @(
-            @{ InvalidName = 'SERVER_01'; ExpectedError = '*invalid characters*' }
-            @{ InvalidName = 'SERVER 01'; ExpectedError = '*invalid characters*' }
-            @{ InvalidName = ''; ExpectedError = '*cannot be null or empty*' }
+            @{ InvalidName = 'SERVER_01'; ExpectedError = '*does not match the*pattern*' }
+            @{ InvalidName = 'SERVER 01'; ExpectedError = '*does not match the*pattern*' }
+            @{ InvalidName = ''; ExpectedError = '*length*is too short*' }
         ) {
             param($InvalidName, $ExpectedError)
             
@@ -39,51 +92,7 @@ Describe "Get-BasicServerInfo" -Tag "Unit", "Example" {
     }
     
     Context "Core Functionality" {
-        BeforeEach {
-            # Mock external dependencies for isolated testing
-            Mock Test-Connection { return $true } -ParameterFilter { $ComputerName -eq 'MOCKSERVER' }
-            Mock New-CimSession { 
-                return [PSCustomObject]@{ ComputerName = 'MOCKSERVER' }
-            } -ParameterFilter { $ComputerName -eq 'MOCKSERVER' }
-            Mock Remove-CimSession { } -ParameterFilter { $CimSession.ComputerName -eq 'MOCKSERVER' }
-            
-            Mock Get-CimInstance {
-                switch ($ClassName) {
-                    'Win32_OperatingSystem' {
-                        return [PSCustomObject]@{
-                            Caption = 'Microsoft Windows Server 2019'
-                            Version = '10.0.17763'
-                            ServicePackMajorVersion = 0
-                            OSArchitecture = '64-bit'
-                            LastBootUpTime = (Get-Date).AddDays(-5)
-                        }
-                    }
-                    'Win32_ComputerSystem' {
-                        return [PSCustomObject]@{
-                            TotalPhysicalMemory = 17179869184  # 16 GB
-                            Manufacturer = 'Dell Inc.'
-                            Model = 'PowerEdge R740'
-                            Domain = 'contoso.com'
-                            Workgroup = $null
-                        }
-                    }
-                    'Win32_Processor' {
-                        return [PSCustomObject]@{
-                            Name = 'Intel(R) Xeon(R) Gold 6248 CPU @ 2.50GHz'
-                            NumberOfCores = 8
-                            NumberOfLogicalProcessors = 16
-                        }
-                    }
-                    'Win32_Service' {
-                        return @(
-                            [PSCustomObject]@{ Name = 'Spooler'; DisplayName = 'Print Spooler'; StartMode = 'Auto'; State = 'Running' },
-                            [PSCustomObject]@{ Name = 'Themes'; DisplayName = 'Themes'; StartMode = 'Auto'; State = 'Running' }
-                        )
-                    }
-                }
-            } -ParameterFilter { $CimSession.ComputerName -eq 'MOCKSERVER' }
-        }
-        
+
         It "Should return expected object structure" {
             $result = Get-BasicServerInfo -ComputerName 'MOCKSERVER'
             
@@ -115,24 +124,34 @@ Describe "Get-BasicServerInfo" -Tag "Unit", "Example" {
     }
     
     Context "Error Handling" {
-        It "Should handle connection failures gracefully" {
-            Mock Test-Connection { return $false } -ParameterFilter { $ComputerName -eq 'OFFLINE' }
-            
-            { Get-BasicServerInfo -ComputerName 'OFFLINE' -ErrorAction SilentlyContinue } | Should -Not -Throw
-        }
-        
-        It "Should continue processing other computers when one fails" {
-            Mock Test-Connection { 
-                if ($ComputerName -eq 'OFFLINE') { return $false }
+
+        # NOTE: PowerShell 7 renamed Test-Connection's -ComputerName parameter to
+        # -TargetName, keeping ComputerName only as an alias. Pester binds mock
+        # variables by the *real* parameter name, so a filter written against
+        # $ComputerName never matches and the mock silently does nothing. Use
+        # $TargetName here.
+        #
+        # These overrides also live in BeforeEach rather than inside It, because a
+        # mock declared inside It does not reliably apply to a function that was
+        # dot-sourced in BeforeAll.
+        BeforeEach {
+            Mock Test-Connection {
+                if ($TargetName -eq 'OFFLINE') { return $false }
                 return $true
             }
-            Mock New-CimSession { 
+            Mock New-CimSession {
                 if ($ComputerName -eq 'OFFLINE') { throw "Connection failed" }
-                return [PSCustomObject]@{ ComputerName = $ComputerName }
+                [PSCustomObject]@{ ComputerName = $ComputerName }
             }
-            
+        }
+
+        It "Should handle connection failures gracefully" {
+            { Get-BasicServerInfo -ComputerName 'OFFLINE' -ErrorAction SilentlyContinue } | Should -Not -Throw
+        }
+
+        It "Should continue processing other computers when one fails" {
             $results = Get-BasicServerInfo -ComputerName @('MOCKSERVER', 'OFFLINE') -ErrorAction SilentlyContinue
-            
+
             # Should get one successful result despite one failure
             $results | Should -Not -BeNullOrEmpty
             $results.ComputerName | Should -Contain 'MOCKSERVER'


### PR DESCRIPTION
Fixes the `PowerShell Quality Gates` job, which failed on #9 and #10.

Two problems were true simultaneously: 24 tests were failing, and the gate was incapable of detecting
them. It reported "All Pester tests passed" on every run.

## Why the gate could not fail

Three compounding defects:

1. **`Run.PassThru` was never enabled.** `Invoke-Pester -Configuration` returns nothing unless
   requested, so `$pesterResults` was `$null` and every subsequent check evaluated against nothing.
   This is why the log read `All Pester tests passed:  of ` with both numbers blank.

2. **Incorrect property names.** The checks used `.Failed` / `.Passed` / `.Total`. In Pester 5/6,
   `.Failed` is a collection of test objects and `.Total` does not exist. `$pesterResults.Failed -gt 0`
   therefore compared test objects against an integer, errored as *"not IComparable"*, yielded empty,
   and evaluated false:

   ```
   Failed  type: List`1  -> 23 items
   ($r.Failed -gt 0) yields: ''   # falsy
   ```

3. **`$LASTEXITCODE` leak.** Pester sets it to the failure count, and GitHub's pwsh wrapper exits with
   whatever it holds. The step therefore failed while displaying a success message — the mismatch that
   made this difficult to diagnose from the log alone.

The gate now uses `PassThru`, the `*Count` properties, and `FailedContainersCount` — the last of which
this repository's own `cicd-integration.md` already mandates, because a container that fails discovery
contributes zero failed tests and would otherwise report green.

Verified in both directions, since a gate that only ever passes was the defect under repair:

| Scenario | Critical issues reported |
|---|---|
| Real suite (green) | 0 |
| Injected failing test | 1 |

## The 24 tests it was masking

All are defects in the repository's own examples, not environment noise.

### `[OutputType([TestResult])]` — 5 failures

`Test-QualityGates.ps1:156` declared a .NET type that does not exist. `TestResult` is the PSTypeName
applied to the output object at line 179. It failed to resolve and took out every `Get-TestResults`
test. Now quoted, matching the pattern `copilot-instructions.md` documents
(`[OutputType('ProcessedData')]`).

### `Get-ADUser` could not be mocked — 6 failures

Not merely unmocked: Pester cannot mock a command that does not exist, and `Get-ADUser` ships with
RSAT. The `Mock Get-ADUser` calls that were present failed with `CommandNotFoundException` before
running. A stub is now defined for `Mock` to replace, along with the mock the `Parameter Validation`
context lacked entirely.

### CIM mocks failed argument transformation

```
Cannot convert the "@{ComputerName=MOCKSERVER}" value of type PSCustomObject
to type "Microsoft.Management.Infrastructure.CimSession[]"
```

PowerShell binds parameters using the original command's metadata even when a command is mocked, so a
`PSCustomObject` stub cannot bind to `-CimSession`; the failure occurs before the mock body runs.
Resolved with `-RemoveParameterType CimSession`.

### Mock scope left tests reaching the network

Mocks were defined in one Context's `BeforeEach`, so `Performance Requirements` invoked the real
`Test-Connection` and failed with *"MOCKSERVER is not reachable via ping"*. Defaults moved to
`Describe` level so no test touches the network.

### `Test-Connection -ComputerName` filters never matched

PowerShell 7 renamed `Test-Connection`'s `-ComputerName` parameter to `-TargetName`, retaining
`ComputerName` only as an alias, and Pester binds mock variables by the real parameter name:

```
bound: TargetName
ComputerName=''   TargetName='MOCKSERVER'
```

`if ($ComputerName -eq 'OFFLINE')` therefore never fired and those mocks silently did nothing; one test
was passing for an unrelated reason. Filters now use `$TargetName`.

### Three assertions expected text PowerShell does not emit

| Assertion | Actual message |
|---|---|
| `*invalid characters*` | `does not match the "^[a-zA-Z0-9\-\.]+$" pattern` |
| `*cannot be null or empty*` | `The character length (0) of the argument is too short` |
| `*cannot be empty*` for `TestName ""` | `Cannot bind argument ... because it is an empty string` |

Replaced with what `ValidatePattern`, `ValidateLength`, and mandatory-parameter binding actually
produce. `$result.PSTypeName` was also changed to `$result.PSObject.TypeNames[0]`, since `PSTypeName`
is consumed during construction and does not persist as a readable property.

An alternative was available: `ValidatePattern` accepts an `ErrorMessage` argument on PowerShell 6+,
which would make the friendlier wording true rather than removing it. It was not taken because
`Basic-Function-Example.ps1` advertises Windows PowerShell 5.1 support, where `ErrorMessage` is
unavailable.

## Result

```
Passed=35  Failed=0  Total=35  FailedContainers=0  LASTEXITCODE=0
```

Tests now assert what the code does. Asserting invented error text is how these decayed unnoticed for
as long as the gate was incapable of reporting it.
