### PR TITLE
docs(readme): reflect the 7.6, Pester 6, and quality-gate changes

### DIFF
--- a/.github/instructions/securitycompliance.instructions.md
+++ b/.github/instructions/securitycompliance.instructions.md
@@ -2,14 +2,18 @@
 mode: 'agent'
 applyTo: "**/*.ps1,**/*.psm1,**/Security/**/*.ps1"
 tools: ['codebase', 'githubRepo']
-description: 'Implements comprehensive security controls and compliance frameworks for PowerShell solutions'
+description: 'Implements security controls and compliance-support patterns for PowerShell solutions'
 ---
 
 # PowerShell Security and Compliance Implementation
 
-Implement robust security controls and compliance frameworks for PowerShell solutions that ensure enterprise-grade
-security, regulatory compliance, threat mitigation, and comprehensive audit capabilities. Apply security-by-design
-principles throughout development.
+Implement security controls for PowerShell solutions: input validation, credential handling, audit
+logging, and threat mitigation. Apply security-by-design principles throughout development.
+
+These patterns support regulatory work such as SOX, GDPR, and HIPAA by producing the audit trails,
+access controls, and data-handling evidence those programmes rely on. They do not make a system
+compliant on their own — that depends on controls, evidence, and audit outside this codebase. Do not
+describe generated code as compliant with any regulation.
 
 ## Security Assessment and Implementation
 
@@ -708,14 +712,17 @@ When implementing security and compliance controls:
 - [ ] **Access controls** implementing principle of least privilege
 - [ ] **Audit trail** maintenance for compliance and forensic requirements
 
-#### Compliance Framework Integration
+#### Compliance Framework Support
 
-- [ ] **SOX compliance** for financial data operations with management approval workflows
-- [ ] **GDPR compliance** for personal data processing with consent management
-- [ ] **HIPAA compliance** for healthcare information with comprehensive safeguards
-- [ ] **PCI DSS compliance** for payment card data (if applicable)
+Controls these programmes depend on. Implementing them supports an audit; it does not by itself
+establish compliance with any of these regulations.
+
+- [ ] **SOX** — approval workflows and tamper-evident audit trails for financial data operations
+- [ ] **GDPR** — consent capture and verification for personal data processing
+- [ ] **GDPR Article 17** — right-to-erasure handling
+- [ ] **HIPAA** — administrative, physical, and technical safeguards for health information
+- [ ] **PCI DSS** — cardholder data handling (if applicable)
 - [ ] **Data retention** policies and automated enforcement
-- [ ] **Right to erasure** implementation for GDPR Article 17 compliance
 
 #### Enterprise Integration Points
 

--- a/.github/workflows/quality-gates-pr.yml
+++ b/.github/workflows/quality-gates-pr.yml
@@ -9,6 +9,12 @@ on:
       - '**.ps1'
       - '**.psm1'
       - '**.psd1'
+      # Markdown must be listed, otherwise a docs-only PR triggers no workflow at
+      # all - including the markdown-lint job below, whose whole purpose is to
+      # gate documentation. This covers README, Documentation/, Troubleshooting/,
+      # and the instruction and prompt files under .github/.
+      - '**.md'
+      - '.markdownlint.json'
       - '.github/workflows/**'
       - 'Documentation/**'
       - 'Templates/**'

--- a/Documentation/Examples/README.md
+++ b/Documentation/Examples/README.md
@@ -9,7 +9,7 @@ organizational requirements. This module serves as both a functional tool and a 
 ## Features
 
 - ✅ **User Management**: Comprehensive Active Directory integration
-- ✅ **Security Auditing**: SOX, GDPR, HIPAA compliance validation
+- ✅ **Security Auditing**: Example checks for controls SOX, GDPR, and HIPAA programmes rely on
 - ✅ **Performance Monitoring**: System performance metrics and alerting
 - ✅ **Configuration Management**: Environment-specific settings and baselines
 - ✅ **Correlation Tracking**: End-to-end operation tracking for troubleshooting

--- a/README.md
+++ b/README.md
@@ -56,7 +56,8 @@ ln -s .copilot-standards/.github/copilot-instructions.md .github/copilot-instruc
 - **Version Baseline**: PowerShell 7.6 (LTS) targeting, with the support lifecycle, version-gated
   cmdlets, and breaking changes for 7.5/7.6 documented in one place
 - **Community Best Practices**: Integrated PowerShell community guidelines
-- **Enterprise Security**: SOX, GDPR, HIPAA compliance frameworks
+- **Enterprise Security**: Audit logging, credential handling, and data-classification patterns
+  covering controls that SOX, GDPR, and HIPAA programmes commonly ask for
 - **Performance Optimization**: Memory management and pipeline efficiency, including the
   version-dependent `+=` guidance that changed in PowerShell 7.5
 - **Modern Tooling**: `Install-PSResource` (Microsoft.PowerShell.PSResourceGet) over PowerShellGet
@@ -83,7 +84,9 @@ ln -s .copilot-standards/.github/copilot-instructions.md .github/copilot-instruc
 
 - **Input Validation**: Comprehensive sanitization and validation patterns
 - **Credential Management**: SecretManagement integration and secure handling
-- **Compliance Frameworks**: Built-in SOX, GDPR, and HIPAA compliance
+- **Regulatory Patterns**: Audit-trail, consent, and access-control patterns for SOX, GDPR, and
+  HIPAA work. These are code patterns and review prompts — they support a compliance programme but
+  do not constitute one, and none of it substitutes for your own controls, evidence, and audit
 - **Security Scanning**: Automated vulnerability detection
 
 ### 📊 Quality Assurance

--- a/README.md
+++ b/README.md
@@ -284,23 +284,19 @@ Create function for infrastructure management with:
 3. Update documentation and examples
 4. Include performance impact analysis
 
-## 📊 Metrics and Success
+## 📊 Measuring Adoption
 
-### Quality Improvements
+No benchmark study backs this repository, so it makes no claims about what adopting it will do for
+your team. Measure it in your own environment instead — the quality gates emit most of what you
+need:
 
-Teams using these standards typically see:
+- **PSScriptAnalyzer findings** per pull request, split by severity
+- **Test coverage** and pass rate from the Pester gate
+- **Security scan findings** — hardcoded secrets and unsafe patterns caught before merge
+- **Documentation completeness** — comment-based help present on exported functions, markdownlint
+  clean
 
-- **40% faster** function development
-- **60% reduction** in code review cycles
-- **80% fewer** security vulnerabilities
-- **90% improvement** in documentation completeness
-
-### Adoption Tracking
-
-- Code quality scores (PSScriptAnalyzer compliance)
-- Security posture improvements
-- Development velocity gains
-- Team satisfaction ratings
+Track these before and after adoption if you want a real before/after comparison.
 
 ## 🆘 Support
 

--- a/README.md
+++ b/README.md
@@ -53,10 +53,16 @@ ln -s .copilot-standards/.github/copilot-instructions.md .github/copilot-instruc
 
 ### 📚 PowerShell Standards
 
+- **Version Baseline**: PowerShell 7.6 (LTS) targeting, with the support lifecycle, version-gated
+  cmdlets, and breaking changes for 7.5/7.6 documented in one place
 - **Community Best Practices**: Integrated PowerShell community guidelines
 - **Enterprise Security**: SOX, GDPR, HIPAA compliance frameworks
-- **Performance Optimization**: Memory management and pipeline efficiency
-- **Testing Standards**: Comprehensive Pester testing patterns
+- **Performance Optimization**: Memory management and pipeline efficiency, including the
+  version-dependent `+=` guidance that changed in PowerShell 7.5
+- **Modern Tooling**: `Install-PSResource` (Microsoft.PowerShell.PSResourceGet) over PowerShellGet
+  v2, with a capability check for Windows PowerShell 5.1 fallback
+- **Testing Standards**: Pester 6 patterns — `Should-*` assertions, `BeforeDiscovery` data,
+  self-contained test files, and 12 supporting guides covering mocking, CI, and templates
 
 ### 🛠️ Development Tools
 
@@ -92,30 +98,42 @@ ln -s .copilot-standards/.github/copilot-instructions.md .github/copilot-instruc
 ```text
 PowerShell-Copilot-Standards/
 ├── .github/
-│   ├── copilot-instructions.md      # Main Copilot instructions
-│   ├── instructions/                # Detailed instruction files
-│   │   └── powershell-version.instructions.md  # Version baseline & lifecycle
-│   ├── prompts/                     # Quick-access prompts
-│   └── workflows/                   # CI/CD templates
-├── Documentation/                   # Reference materials
-├── Templates/                       # Project templates
-├── Tools/                          # Setup and validation scripts
-├── Troubleshooting/                # Organized troubleshooting guides
-└── README.md                       # This file
+│   ├── copilot-instructions.md          # Main Copilot instructions (applied automatically)
+│   ├── instructions/                    # 12 scoped instruction files, applied by `applyTo` glob
+│   │   ├── powershell-version.instructions.md   # Version baseline, lifecycle, breaking changes
+│   │   ├── pester.instructions.md               # Pester 6 core testing standards
+│   │   └── pester-supporting-docs/              # 12 guides: mocking, CI, templates, v6 migration
+│   ├── prompts/                         # 10 `/prompt-name` files for Copilot Chat
+│   └── workflows/                       # Quality gates run on every pull request
+├── Documentation/                       # Reference materials and worked examples
+├── Templates/                           # Module, script-collection, and application templates
+├── Tools/                               # Install-CopilotStandards, Test-StandardsCompliance
+├── Troubleshooting/                     # Organized problem-solving guides
+├── .markdownlint.json                   # Documentation lint rules enforced in CI
+└── README.md                            # This file
 ```
 
 ## 🚀 Getting Started
 
 ### 1. Enable Copilot Instructions
 
-In VS Code, add to your settings.json:
+Current VS Code picks these up with no configuration: `.github/copilot-instructions.md` is applied
+automatically, `.github/instructions/*.instructions.md` apply to files matching their `applyTo`
+glob, and `.github/prompts/*.prompt.md` are available as `/prompt-name` in Copilot Chat.
+
+You only need settings if you keep these files somewhere other than the defaults:
 
 ```json
 {
-  "chat.promptFiles": true,
-  "github.copilot.chat.codeGeneration.useInstructionFiles": true
+  "chat.instructionsFilesLocations": { ".github/instructions": true },
+  "chat.promptFilesLocations": { ".github/prompts": true }
 }
 ```
+
+> Older guidance recommended `chat.promptFiles` and
+> `github.copilot.chat.codeGeneration.useInstructionFiles`. Settings-based instructions were
+> deprecated in VS Code 1.102 in favour of the file-based layout above; neither setting is required
+> now.
 
 ### 2. Choose Your Integration Method
 
@@ -178,19 +196,27 @@ git submodule add https://github.com/fadwen/PowerShell-Copilot-Standards.git .co
 
 ### Automated Testing
 
-All generated code includes:
+Standards for the code you generate — Pester 6 throughout:
 
-- **Unit Tests**: Pester tests with 80%+ coverage
+- **Unit Tests**: Pester tests targeting 80%+ coverage
 - **Integration Tests**: External dependency validation
 - **Performance Tests**: Benchmarking and regression detection
 - **Security Tests**: Input validation and credential handling
 
 ### Quality Gates
 
-- **PSScriptAnalyzer**: Zero violations with enterprise rules
-- **Security Scanning**: Credential leak and vulnerability detection
+These run against this repository on every pull request, and the templates set the same gates up
+for yours:
+
+- **PSScriptAnalyzer**: Zero errors in production files (test files are analyzed separately, since
+  patterns like a hardcoded `-ComputerName 'MOCKSERVER'` are legitimate in a mock)
+- **Pester**: Fails on `FailedCount` _and_ `FailedContainersCount` — a file that fails discovery
+  contributes zero failed tests and would otherwise read green
+- **Security Scanning**: Credential leak and vulnerability detection. Secret patterns apply to all
+  files; code-execution patterns apply only to `.ps1`/`.psm1`, since a `.psd1` is restricted data
+  and cannot invoke a cmdlet
+- **Documentation**: markdownlint over all Markdown, plus comment-based help validation
 - **Community Standards**: PowerShell best practices compliance
-- **Documentation**: Complete comment-based help validation
 
 ## 🔧 Customization
 
@@ -227,6 +253,11 @@ Create function for infrastructure management with:
 
 ### Core Documentation
 
+- **[PowerShell Version Baseline](./.github/instructions/powershell-version.instructions.md)**:
+  Support lifecycle, choosing a target, version-gated features, breaking changes
+- **[Pester 6 Testing Standards](./.github/instructions/pester.instructions.md)**: Core testing
+  requirements, with [12 supporting guides](./.github/instructions/pester-supporting-docs/) for
+  mocking, CI, templates, and v6 migration
 - **[Implementation Guide](./Documentation/Implementation-Guide.md)**: Step-by-step setup and usage
 - **[PowerShell Best Practices](./Documentation/PowerShell-Best-Practices.md)**: Community standards reference
 - **[Enterprise Extensions](./Documentation/Enterprise-Extensions.md)**: Organization-specific additions


### PR DESCRIPTION
Updates the README to describe the repository as it stands after #8–#11, removes claims that cannot be
substantiated, and fixes two items that were incorrect independently of that work.

## Corrected for #8–#11

- **PowerShell Standards** — adds the 7.6 version baseline, `Install-PSResource` over PowerShellGet v2,
  and the version-dependent `+=` guidance. "Comprehensive Pester testing patterns" now names Pester 6
  and its 12 supporting guides.
- **Repository structure** — `instructions/` was a single line concealing 12 instruction files and 12
  Pester supporting guides; `.markdownlint.json` was absent. All counts verified against the tree.
- **Quality gates** — rewritten to describe what runs on a pull request. The markdownlint gate was
  absent from the list, as were the `FailedContainersCount` check and the reason test files are
  analyzed separately from production files.
- **Core documentation** — links the version baseline and Pester 6 standards. They are the two most
  substantial documents in the repository and neither was referenced.

## Removed: unsourced adoption metrics

The README claimed teams "typically see" 40% faster function development, 60% reduction in code review
cycles, 80% fewer security vulnerabilities, and 90% improvement in documentation completeness.

No study, survey, or telemetry supports any of those figures. They were presented as measured results,
which is why they were removed rather than softened — they appeared alongside claims that are
verifiable and undermined them.

Replaced with the signals the quality gates emit, and an explicit statement that the repository makes no
claim about outcomes:

- PSScriptAnalyzer findings per pull request, by severity
- Test coverage and pass rate from the Pester gate
- Security scan findings caught before merge
- Documentation completeness — comment-based help, markdownlint clean

The former "Adoption Tracking" list survived in substance, having already named real signals rather than
invented figures. The repository was checked for similar claims; these four were the only fabricated
percentages present.

## Removed: overstated compliance claims

Instruction files supply code patterns and review prompts. They cannot render a system compliant with a
regulation; that rests on controls, evidence, and audit outside this codebase. Four locations stated
otherwise:

| Previous | Replacement |
|---|---|
| README: "Built-in SOX, GDPR, and HIPAA compliance" | The audit-trail, consent, and access-control patterns actually shipped, described as supporting a compliance programme rather than constituting one |
| README: "SOX, GDPR, HIPAA compliance frameworks" | The concrete controls covered |
| `securitycompliance.instructions.md`: patterns "that **ensure** ... regulatory compliance" | What the controls do, plus a direct instruction not to describe generated code as compliant with any regulation |
| Its checklist: `[ ] HIPAA compliance ... with comprehensive safeguards` | The controls each programme depends on, under a heading stating this supports an audit rather than establishing compliance |
| `Documentation/Examples`: "SOX, GDPR, HIPAA compliance validation" | Example checks for controls those programmes rely on |

The instruction-file wording carried the most weight: that file drives Copilot, so the overstatement was
reproducible into every project generated from these standards.

Compliance references inside code samples and example help text were left unchanged. They are already
hedged and describe what a given function records, not what this repository delivers.

## Incorrect independently of #8–#11

Setup step 1 instructed users to set `chat.promptFiles` and
`github.copilot.chat.codeGeneration.useInstructionFiles`. Settings-based instructions were deprecated in
VS Code 1.102, and the file-based layout this repository ships is loaded without configuration.
Replaced with the current `chat.instructionsFilesLocations` / `chat.promptFilesLocations`, required only
for non-default paths, with a note on why the previous keys are gone. This is the first instruction a
new user follows.

## Also fixed: documentation-only PRs ran no checks

Surfaced by this PR being the first documentation-only change: it initially reported "no checks reported
on the branch".

The `pull_request` paths filter listed `.ps1`/`.psm1`/`.psd1`, `Documentation/`, `Templates/` and
workflows, but no Markdown. A PR touching only `README.md`, or only the instruction files under
`.github/`, triggered nothing — including the markdown-lint job in that same workflow, whose purpose is
to gate documentation.

#10 ran only because it also touched `Documentation/` and `.github/workflows/`. A documentation-only
change would have bypassed the lint gate entirely. `'**.md'` and `'.markdownlint.json'` added.

## Verification

- All internal links resolve (12/12).
- `Install-CopilotStandards.ps1 -StandardsType "Module"/"Basic"` and `Test-StandardsCompliance.ps1 -Path`
  match the real parameters.
- File counts checked: 12 `*.instructions.md`, 12 supporting docs, 10 prompt files.
- PSScriptAnalyzer reports 11 findings, but all 6 errors are `-ComputerName 'MOCKSERVER'` in a test file
  that the gate correctly excludes. Production files are clean, so "zero violations" was accurate; the
  production/test distinction is now explicit rather than implied.

## Out of scope

- **Coverage** — the README targets 80%+; the repository's own suite reports 22.77%, and the workflow
  warns below the threshold rather than failing. "Includes 80%+ coverage" was softened to "targeting",
  as it describes generated code. Whether the gate should enforce the threshold is a separate decision.
- **Clone URL casing** — the README uses `PowerShell-Copilot-Standards`; the remote is
  `Powershell-Copilot-Standards`. GitHub redirects, so it resolves.
