### PR TITLE
test: cover the Tools scripts and fix the bugs that exposed

### DIFF
--- a/.github/workflows/quality-gates-pr.yml
+++ b/.github/workflows/quality-gates-pr.yml
@@ -64,21 +64,40 @@ jobs:
                 $_.FullName -notlike "*\node_modules\*"
             }
 
-            $productionFiles = $allPsFiles | Where-Object {
-                $_.Name -notlike "*.Tests.ps1" -and
-                $_.Name -notlike "*test*" -and
-                $_.FullName -notlike "*\Tests\*"
+            # Files that intentionally demonstrate violations. Excluded from
+            # production analysis on purpose, and listed explicitly so the reason is
+            # visible - the previous "*test*" name filter excluded them by accident,
+            # and excluded Test-StandardsCompliance.ps1 with them. Test- is an
+            # approved PowerShell verb, so a name filter cannot tell a test file from
+            # a tool named with it.
+            $demonstrationFiles = @(
+                'Test-QualityGates.ps1'
+            )
+
+            $isTestFile = {
+                param($f)
+                $f.Name -like "*.Tests.ps1" -or $f.FullName -like "*\Tests\*"
             }
 
-            $testFiles = $allPsFiles | Where-Object {
-                $_.Name -like "*.Tests.ps1" -or
-                $_.Name -like "*test*" -or
-                $_.FullName -like "*\Tests\*"
+            $testFiles = $allPsFiles | Where-Object { & $isTestFile $_ }
+
+            $productionFiles = $allPsFiles | Where-Object {
+                -not (& $isTestFile $_) -and $demonstrationFiles -notcontains $_.Name
+            }
+
+            # Coverage is measured only over code this repository ships and executes.
+            # Templates are scaffolding meant to be copied and filled in, and
+            # Documentation examples are illustrations - covering either measures
+            # nothing. Including them was why coverage read 22.77% while the one
+            # tested file sat at 98%.
+            $coverageFiles = $productionFiles | Where-Object {
+                $_.Extension -eq '.ps1' -and $_.FullName -like "*$([IO.Path]::DirectorySeparatorChar)Tools$([IO.Path]::DirectorySeparatorChar)*"
             }
 
             Write-Host "📊 Found $($allPsFiles.Count) total PowerShell files" -ForegroundColor Yellow
             Write-Host "📦 Production files: $($productionFiles.Count)" -ForegroundColor Green
             Write-Host "🧪 Test files: $($testFiles.Count)" -ForegroundColor Blue
+            Write-Host "📈 Coverage scope: $($coverageFiles.Count) file(s) under Tools/" -ForegroundColor Blue
 
             $totalIssues = 0
             $criticalIssues = 0
@@ -174,7 +193,7 @@ jobs:
                 $pesterConfig.Run.PassThru = $true
                 $pesterConfig.Output.Verbosity = 'Detailed'
                 $pesterConfig.CodeCoverage.Enabled = $true
-                $pesterConfig.CodeCoverage.Path = $productionFiles.FullName
+                $pesterConfig.CodeCoverage.Path = $coverageFiles.FullName
 
                 $pesterResults = Invoke-Pester -Configuration $pesterConfig
 

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,9 @@
 *.log
 Temp/
 *.tmp
+
+# Test and coverage artifacts. Install-CopilotStandards.ps1 already writes these
+# into the .gitignore it generates for consumers; this repo was missing them.
+TestResults/
+coverage.xml
+Tests/Results/

--- a/README.md
+++ b/README.md
@@ -310,15 +310,6 @@ Track these before and after adoption if you want a real before/after comparison
 - **Documentation**: Check the Documentation folder
 - **Troubleshooting**: See organized guides in Troubleshooting folder
 
-### Enterprise Support
-
-For enterprise implementation assistance:
-
-- Implementation consulting
-- Custom instruction development
-- Team training and onboarding
-- Metrics and success tracking
-
 ## 📄 License
 
 This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.

--- a/Tools/Install-CopilotStandards.ps1
+++ b/Tools/Install-CopilotStandards.ps1
@@ -229,9 +229,8 @@ coverage.xml
 
         Write-Information "PowerShell Copilot Standards installed successfully!" -InformationAction Continue
         Write-Information "Next steps:" -InformationAction Continue
-        Write-Information "  1. Enable prompt files in VS Code settings:" -InformationAction Continue
-        Write-Information "     `"chat.promptFiles`": true" -InformationAction Continue
-        Write-Information "     `"github.copilot.chat.codeGeneration.useInstructionFiles`": true" -InformationAction Continue
+        Write-Information "  1. No VS Code settings needed - .github/copilot-instructions.md," -InformationAction Continue
+        Write-Information "     .github/instructions/ and .github/prompts/ are picked up by default" -InformationAction Continue
         Write-Information "  2. Test with /new-function in Copilot Chat" -InformationAction Continue
         Write-Information "  3. Run .\Tools\Test-StandardsCompliance.ps1 to validate" -InformationAction Continue
         Write-Information "  4. Create your first function using enterprise standards" -InformationAction Continue

--- a/Tools/Test-StandardsCompliance.ps1
+++ b/Tools/Test-StandardsCompliance.ps1
@@ -59,7 +59,10 @@ param(
     [string]$OutputFormat = 'Console',
     
     [Parameter(HelpMessage = "Path to save detailed results")]
-    [string]$OutputPath
+    [string]$OutputPath,
+
+    [Parameter(HelpMessage = "Return the results object instead of exiting with a status code")]
+    [switch]$PassThru
 )
 
 begin {
@@ -141,8 +144,10 @@ process {
         Write-Information "Found $($psFiles.Count) PowerShell files to analyze" -InformationAction Continue
         
         if ($psFiles.Count -eq 0) {
+            # Do not emit $results here - the end block owns the single return, and
+            # emitting from both produced two objects on the pipeline.
             Write-Warning "No PowerShell files found to analyze"
-            return $results
+            return
         }
         
         # Progress tracking
@@ -155,6 +160,11 @@ process {
             Write-Progress -Activity "Analyzing PowerShell Files" -Status "Processing $($file.Name)" -PercentComplete $percentComplete
             Write-Verbose "Analyzing: $($file.Name) ($currentFile/$($psFiles.Count))"
             
+            # $fileResult must exist before the analysis runs. Previously the whole
+            # analysis lived inside this hashtable's initializer, assigned to
+            # AnalysisTime, and mutated $fileResult.Issues while $fileResult was
+            # still being constructed - so the first file threw "property 'Issues'
+            # cannot be found" and later files mutated the *previous* file's result.
             $fileResult = @{
                 FileName = $file.Name
                 FilePath = $file.FullName
@@ -162,8 +172,11 @@ process {
                 FileSize = $file.Length
                 Issues = @()
                 Passed = $true
-                AnalysisTime = Measure-Command {
-                    
+                AnalysisTime = [TimeSpan]::Zero
+            }
+
+            $fileResult.AnalysisTime = Measure-Command {
+
                     # PSScriptAnalyzer analysis
                     $fileAnalysisResults = Invoke-ScriptAnalyzer -Path $file.FullName -Severity @('Error', 'Warning', 'Information')
                     
@@ -292,19 +305,18 @@ process {
                         }
                     }
                 }
-            }
-            
+
             $results.FileResults += $fileResult
             
             if ($fileResult.Passed) {
                 $results.PassedFiles++
                 if ($Detailed) {
-                    Write-Information "✅ $($file.Name)" -InformationAction Continue
+                    Write-Information "[PASS] $($file.Name)" -InformationAction Continue
                 }
             } else {
                 $results.FailedFiles++
                 if ($Detailed) {
-                    Write-Information "❌ $($file.Name) - $($fileResult.Issues.Count) issues" -InformationAction Continue
+                    Write-Information "[FAIL] $($file.Name) - $($fileResult.Issues.Count) issues" -InformationAction Continue
                 }
             }
         }
@@ -316,7 +328,12 @@ process {
         $results.Summary = @{
             CompliancePercentage = if ($results.TotalFiles -gt 0) { [math]::Round(($results.PassedFiles / $results.TotalFiles) * 100, 1) } else { 0 }
             OverallStatus = if ($results.CriticalIssues -eq 0 -and $results.HighIssues -eq 0) { 'PASSED' } elseif ($results.CriticalIssues -eq 0) { 'WARNING' } else { 'FAILED' }
-            TotalAnalysisTime = ($results.FileResults | Measure-Object -Property AnalysisTime -Sum).Sum
+            # Measure-Object -Sum cannot total TimeSpan values ("Input object ... is
+            # not numeric"), and $ErrorActionPreference is Stop, so this aborted the
+            # whole analysis. Sum the ticks and rebuild the TimeSpan.
+            TotalAnalysisTime = [TimeSpan]::FromTicks(
+                ($results.FileResults | ForEach-Object { $_.AnalysisTime.Ticks } | Measure-Object -Sum).Sum
+            )
             AverageFileSize = if ($results.TotalFiles -gt 0) { [math]::Round(($results.FileResults | Measure-Object -Property FileSize -Average).Average / 1KB, 2) } else { 0 }
         }
     }
@@ -434,16 +451,22 @@ end {
         Write-Information "    /optimize-performance for performance issues" -InformationAction Continue
         Write-Information "    /code-analysis for comprehensive analysis" -InformationAction Continue
         Write-Information "    /validate-standards for community standards compliance" -InformationAction Continue
-        
-        # Exit with error code for CI/CD integration
-        exit 1
-    } else {
-        Write-Information "`nAll files meet PowerShell enterprise standards!" -InformationAction Continue
-        exit 0
     }
-    
+    else {
+        Write-Information "`nAll files meet PowerShell enterprise standards!" -InformationAction Continue
+    }
+
     Write-Verbose "Analysis completed in $([math]::Round($results.Summary.TotalAnalysisTime.TotalSeconds, 2)) seconds"
-    
-    # Return results object for programmatic use
-    return $results
+
+    # Return the results object for programmatic use. `exit` terminates the whole
+    # host, so a caller that wants the data - a test, or another script - cannot
+    # use the CLI path. This is why the original `return` below the exits was
+    # unreachable.
+    if ($PassThru) {
+        return $results
+    }
+
+    # CLI/CI contract, unchanged when -PassThru is not supplied: non-zero exit
+    # when any issue was found.
+    if ($results.TotalIssues -gt 0) { exit 1 } else { exit 0 }
 }

--- a/Tools/Tests/Install-CopilotStandards.Tests.ps1
+++ b/Tools/Tests/Install-CopilotStandards.Tests.ps1
@@ -1,0 +1,185 @@
+#Requires -Module Pester
+
+BeforeAll {
+    $script:ScriptPath = Join-Path $PSScriptRoot '..' 'Install-CopilotStandards.ps1' | Resolve-Path
+}
+
+Describe 'Install-CopilotStandards' -Tag 'Unit', 'Tools' {
+
+    BeforeEach {
+        # A fresh throwaway project directory per test - the script writes to disk,
+        # so tests must never share one.
+        $script:ProjectPath = Join-Path ([System.IO.Path]::GetTempPath()) "ics-$([System.Guid]::NewGuid().ToString('N'))"
+        New-Item -Path $script:ProjectPath -ItemType Directory -Force | Out-Null
+    }
+
+    AfterEach {
+        if (Test-Path $script:ProjectPath) {
+            Remove-Item $script:ProjectPath -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+
+    Context 'Parameter validation' {
+
+        It 'Rejects a ProjectPath that does not exist' {
+            $missing = Join-Path $script:ProjectPath 'no-such-directory'
+            { & $script:ScriptPath -ProjectPath $missing -InformationAction SilentlyContinue } |
+                Should -Throw '*does not exist*'
+        }
+
+        It 'Rejects a ProjectPath that is a file rather than a directory' {
+            $file = Join-Path $script:ProjectPath 'a-file.txt'
+            Set-Content -Path $file -Value 'not a directory'
+            { & $script:ScriptPath -ProjectPath $file -InformationAction SilentlyContinue } |
+                Should -Throw '*does not exist*'
+        }
+
+        It 'Rejects an unknown StandardsType' {
+            { & $script:ScriptPath -ProjectPath $script:ProjectPath -StandardsType 'NotAType' -InformationAction SilentlyContinue } |
+                Should -Throw '*ValidateSet*'
+        }
+
+        It 'Rejects an unknown LinkType' {
+            { & $script:ScriptPath -ProjectPath $script:ProjectPath -LinkType 'Telepathy' -InformationAction SilentlyContinue } |
+                Should -Throw '*ValidateSet*'
+        }
+    }
+
+    Context 'Copy installation' {
+
+        BeforeEach {
+            & $script:ScriptPath -ProjectPath $script:ProjectPath -StandardsType 'Basic' -LinkType 'Copy' -InformationAction SilentlyContinue
+        }
+
+        It 'Creates the .github directory' {
+            Join-Path $script:ProjectPath '.github' | Should -Exist
+        }
+
+        It 'Copies the main Copilot instructions' {
+            Join-Path $script:ProjectPath '.github/copilot-instructions.md' | Should -Exist
+        }
+
+        It 'Copies the instructions directory with its content' {
+            $dir = Join-Path $script:ProjectPath '.github/instructions'
+            $dir | Should -Exist
+            (Get-ChildItem $dir -Filter '*.instructions.md').Count | Should -BeGreaterThan 0
+        }
+
+        It 'Copies the prompts directory with its content' {
+            $dir = Join-Path $script:ProjectPath '.github/prompts'
+            $dir | Should -Exist
+            (Get-ChildItem $dir -Filter '*.prompt.md').Count | Should -BeGreaterThan 0
+        }
+
+        It 'Creates a .gitignore covering PowerShell and test artifacts' {
+            $gitignore = Join-Path $script:ProjectPath '.gitignore'
+            $gitignore | Should -Exist
+            $content = Get-Content $gitignore -Raw
+            $content | Should -Match '\*\.ps1\.bak'
+            $content | Should -Match 'TestResults/'
+        }
+    }
+
+    Context 'Project structure per StandardsType' {
+
+        It 'Basic creates Tests and Troubleshooting' {
+            & $script:ScriptPath -ProjectPath $script:ProjectPath -StandardsType 'Basic' -InformationAction SilentlyContinue
+
+            Join-Path $script:ProjectPath 'Tests' | Should -Exist
+            Join-Path $script:ProjectPath 'Troubleshooting' | Should -Exist
+        }
+
+        It 'Module adds the module layout' {
+            & $script:ScriptPath -ProjectPath $script:ProjectPath -StandardsType 'Module' -InformationAction SilentlyContinue
+
+            foreach ($folder in 'Public', 'Private', 'Classes', 'Documentation') {
+                Join-Path $script:ProjectPath $folder | Should -Exist
+            }
+            Join-Path $script:ProjectPath 'Tests/Unit' | Should -Exist
+            Join-Path $script:ProjectPath 'Tests/Integration' | Should -Exist
+        }
+
+        It 'Enterprise adds Configuration, Scripts, Tools and a security test folder' {
+            & $script:ScriptPath -ProjectPath $script:ProjectPath -StandardsType 'Enterprise' -InformationAction SilentlyContinue
+
+            foreach ($folder in 'Configuration', 'Scripts', 'Tools') {
+                Join-Path $script:ProjectPath $folder | Should -Exist
+            }
+            Join-Path $script:ProjectPath 'Tests/Security' | Should -Exist
+            Join-Path $script:ProjectPath 'Troubleshooting/Integration' | Should -Exist
+        }
+    }
+
+    Context 'Idempotence and non-destructive behaviour' {
+
+        It 'Does not overwrite an existing .gitignore' {
+            $gitignore = Join-Path $script:ProjectPath '.gitignore'
+            Set-Content -Path $gitignore -Value '# hand-written, keep me'
+
+            & $script:ScriptPath -ProjectPath $script:ProjectPath -InformationAction SilentlyContinue
+
+            Get-Content $gitignore -Raw | Should -Match 'hand-written, keep me'
+        }
+
+        It 'Can run twice without error' {
+            & $script:ScriptPath -ProjectPath $script:ProjectPath -StandardsType 'Module' -InformationAction SilentlyContinue
+            { & $script:ScriptPath -ProjectPath $script:ProjectPath -StandardsType 'Module' -InformationAction SilentlyContinue } |
+                Should -Not -Throw
+        }
+    }
+
+    Context 'WhatIf support' {
+
+        It 'Creates nothing when -WhatIf is supplied' {
+            & $script:ScriptPath -ProjectPath $script:ProjectPath -StandardsType 'Enterprise' -WhatIf -InformationAction SilentlyContinue
+
+            Join-Path $script:ProjectPath '.github' | Should -Not -Exist
+            Join-Path $script:ProjectPath 'Public' | Should -Not -Exist
+            Join-Path $script:ProjectPath '.gitignore' | Should -Not -Exist
+        }
+    }
+
+    Context 'Symlink installation' {
+
+        It 'Still installs the instructions, whether it links or falls back to copy' {
+            # Creating a symlink on Windows needs elevation. Unelevated, the script
+            # warns and re-invokes itself with -LinkType Copy. Both outcomes must
+            # leave the caller with usable instructions, and CI may run either way.
+            & $script:ScriptPath -ProjectPath $script:ProjectPath -LinkType 'Symlink' `
+                -InformationAction SilentlyContinue -WarningAction SilentlyContinue
+
+            Join-Path $script:ProjectPath '.github/copilot-instructions.md' | Should -Exist
+        }
+    }
+
+    Context 'Submodule installation' {
+
+        It 'Refuses a target that is not a git repository' {
+            {
+                & $script:ScriptPath -ProjectPath $script:ProjectPath -LinkType 'Submodule' `
+                    -InformationAction SilentlyContinue
+            } | Should -Throw '*not a git repository*'
+        }
+
+        It 'Leaves the working directory unchanged after failing' {
+            $before = (Get-Location).Path
+            try {
+                & $script:ScriptPath -ProjectPath $script:ProjectPath -LinkType 'Submodule' `
+                    -InformationAction SilentlyContinue -ErrorAction SilentlyContinue
+            }
+            catch { }
+            (Get-Location).Path | Should -Be $before
+        }
+    }
+
+    Context 'Guidance it prints' {
+
+        It 'Does not recommend the VS Code settings deprecated in 1.102' {
+            $output = & $script:ScriptPath -ProjectPath $script:ProjectPath -InformationAction Continue 6>&1 |
+                Out-String
+
+            $output | Should -Not -Match 'chat\.promptFiles'
+            $output | Should -Not -Match 'useInstructionFiles'
+        }
+    }
+}

--- a/Tools/Tests/Test-StandardsCompliance.Tests.ps1
+++ b/Tools/Tests/Test-StandardsCompliance.Tests.ps1
@@ -1,0 +1,304 @@
+#Requires -Module Pester
+
+BeforeAll {
+    $script:ScriptPath = Join-Path $PSScriptRoot '..' 'Test-StandardsCompliance.ps1' | Resolve-Path
+
+    # Invoke with -PassThru so the script returns its results object rather than
+    # calling exit, which would terminate the Pester run.
+    function Invoke-Compliance {
+        param([string]$Path, [hashtable]$Extra = @{})
+        & $script:ScriptPath -Path $Path -PassThru -InformationAction SilentlyContinue @Extra
+    }
+
+    function New-Fixture {
+        param([string]$Name, [string]$Content)
+        $file = Join-Path $script:FixturePath $Name
+        Set-Content -LiteralPath $file -Value $Content -Encoding UTF8
+        return $file
+    }
+}
+
+Describe 'Test-StandardsCompliance' -Tag 'Unit', 'Tools' {
+
+    BeforeEach {
+        $script:FixturePath = Join-Path ([System.IO.Path]::GetTempPath()) "tsc-$([System.Guid]::NewGuid().ToString('N'))"
+        New-Item -Path $script:FixturePath -ItemType Directory -Force | Out-Null
+    }
+
+    AfterEach {
+        if (Test-Path $script:FixturePath) {
+            Remove-Item $script:FixturePath -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+
+    Context 'Parameter validation' {
+
+        It 'Rejects a Path that does not exist' {
+            { & $script:ScriptPath -Path (Join-Path $script:FixturePath 'nope') -PassThru -InformationAction SilentlyContinue } |
+                Should -Throw
+        }
+
+        It 'Rejects an unsupported OutputFormat' {
+            { & $script:ScriptPath -Path $script:FixturePath -OutputFormat 'Interpretive-Dance' -PassThru -InformationAction SilentlyContinue } |
+                Should -Throw '*ValidateSet*'
+        }
+    }
+
+    Context 'Analysis results' {
+
+        It 'Returns a results object when -PassThru is supplied' {
+            New-Fixture -Name 'Get-Clean.ps1' -Content @'
+function Get-Clean {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$Name
+    )
+    Write-Output $Name
+}
+'@
+            $result = Invoke-Compliance -Path $script:FixturePath
+
+            $result | Should -Not -BeNullOrEmpty
+            $result.TotalFiles | Should -Be 1
+            $result.CorrelationId | Should -Not -BeNullOrEmpty
+            $result.Summary.OverallStatus | Should -BeIn @('PASSED', 'WARNING', 'FAILED')
+        }
+
+        It 'Counts every PowerShell file it finds' {
+            New-Fixture -Name 'One.ps1' -Content 'Write-Output 1'
+            New-Fixture -Name 'Two.psm1' -Content 'Write-Output 2'
+            New-Fixture -Name 'Three.psd1' -Content '@{ ModuleVersion = ''1.0.0'' }'
+
+            (Invoke-Compliance -Path $script:FixturePath).TotalFiles | Should -Be 3
+        }
+
+        It 'Accepts a single file as the Path' {
+            $file = New-Fixture -Name 'Single.ps1' -Content 'Write-Output 1'
+
+            (Invoke-Compliance -Path $file).TotalFiles | Should -Be 1
+        }
+    }
+
+    Context 'Community standards detection' {
+
+        It 'Flags a function using a non-approved verb' {
+            New-Fixture -Name 'BadVerb.ps1' -Content @'
+function Process-Thing {
+    param([string]$Data)
+    Write-Output $Data
+}
+'@
+            $result = Invoke-Compliance -Path $script:FixturePath
+
+            $result.ComplianceIssues.RuleName | Should -Contain 'UseApprovedVerbs'
+            ($result.ComplianceIssues | Where-Object RuleName -eq 'UseApprovedVerbs').Message |
+                Should -Match 'Process'
+        }
+
+        It 'Does not flag a function using an approved verb' {
+            New-Fixture -Name 'GoodVerb.ps1' -Content @'
+function Get-Thing {
+    param([string]$Data)
+    Write-Output $Data
+}
+'@
+            $result = Invoke-Compliance -Path $script:FixturePath
+
+            $result.ComplianceIssues.RuleName | Should -Not -Contain 'UseApprovedVerbs'
+        }
+    }
+
+    Context 'Security detection' {
+
+        It 'Flags a hardcoded password' {
+            New-Fixture -Name 'Secret.ps1' -Content @'
+$config = @{
+    password = "hunter2plus"
+}
+Write-Output $config
+'@
+            $result = Invoke-Compliance -Path $script:FixturePath
+
+            $result.SecurityIssues | Should -Not -BeNullOrEmpty
+            $result.SecurityIssues.Type | Should -Contain 'HardcodedPassword'
+        }
+
+        It 'Does not flag a file with no secrets' {
+            New-Fixture -Name 'NoSecret.ps1' -Content 'Write-Output "nothing to see"'
+
+            (Invoke-Compliance -Path $script:FixturePath).SecurityIssues | Should -BeNullOrEmpty
+        }
+    }
+
+    Context 'Version-aware array append rule' {
+
+        # PowerShell 7.5 optimised += on object arrays, so the rule only applies to
+        # files that declare a target where it is still O(n^2).
+
+        It 'Flags += when the file declares no target version' {
+            New-Fixture -Name 'NoRequires.ps1' -Content @'
+$items = @()
+foreach ($x in 1..10) { $items += $x }
+Write-Output $items
+'@
+            $result = Invoke-Compliance -Path $script:FixturePath
+
+            $result.PerformanceIssues.Type | Should -Contain 'ArrayAppending'
+        }
+
+        It 'Flags += when the file targets 5.1' {
+            New-Fixture -Name 'Legacy.ps1' -Content @'
+#requires -Version 5.1
+$items = @()
+foreach ($x in 1..10) { $items += $x }
+Write-Output $items
+'@
+            (Invoke-Compliance -Path $script:FixturePath).PerformanceIssues.Type |
+                Should -Contain 'ArrayAppending'
+        }
+
+        It 'Does not flag += when the file targets 7.6' {
+            New-Fixture -Name 'Modern.ps1' -Content @'
+#requires -Version 7.6
+$items = @()
+foreach ($x in 1..10) { $items += $x }
+Write-Output $items
+'@
+            (Invoke-Compliance -Path $script:FixturePath).PerformanceIssues.Type |
+                Should -Not -Contain 'ArrayAppending'
+        }
+
+        It 'Flags ArrayList on any version' {
+            New-Fixture -Name 'Legacy-Collection.ps1' -Content @'
+#requires -Version 7.6
+$items = [System.Collections.ArrayList]::new()
+[void]$items.Add(1)
+Write-Output $items
+'@
+            (Invoke-Compliance -Path $script:FixturePath).PerformanceIssues.Type |
+                Should -Contain 'LegacyCollectionType'
+        }
+    }
+
+    Context 'Output formats' {
+
+        It 'Writes a JSON report when asked' {
+            New-Fixture -Name 'Sample.ps1' -Content 'Write-Output 1'
+            $out = Join-Path $script:FixturePath 'report.json'
+
+            Invoke-Compliance -Path $script:FixturePath -Extra @{ OutputFormat = 'JSON'; OutputPath = $out } | Out-Null
+
+            $out | Should -Exist
+            { Get-Content $out -Raw | ConvertFrom-Json } | Should -Not -Throw
+            (Get-Content $out -Raw | ConvertFrom-Json).TotalFiles | Should -Be 1
+        }
+    }
+
+    Context 'Empty input' {
+
+        It 'Handles a directory with no PowerShell files' {
+            $result = Invoke-Compliance -Path $script:FixturePath
+
+            $result.TotalFiles | Should -Be 0
+        }
+
+        It 'Emits exactly one results object, not one per code path' {
+            New-Fixture -Name 'Sample.ps1' -Content 'Write-Output 1'
+
+            @(Invoke-Compliance -Path $script:FixturePath).Count | Should -Be 1
+        }
+    }
+
+    Context 'Reporting' {
+
+        It 'Reports a clean run as PASSED' {
+            New-Fixture -Name 'Clean.ps1' -Content @'
+function Get-Clean {
+    [CmdletBinding()]
+    param([Parameter(Mandatory)][string]$Name)
+    Write-Output $Name
+}
+'@
+            $result = Invoke-Compliance -Path $script:FixturePath
+
+            $result.Summary.OverallStatus | Should -Be 'PASSED'
+            $result.PassedFiles | Should -Be 1
+            $result.FailedFiles | Should -Be 0
+        }
+
+        It 'Reports a run with a non-approved verb as FAILED' {
+            New-Fixture -Name 'BadVerb.ps1' -Content 'function Process-Thing { Write-Output 1 }'
+            $result = Invoke-Compliance -Path $script:FixturePath
+
+            $result.Summary.OverallStatus | Should -Be 'FAILED'
+            $result.FailedFiles | Should -Be 1
+            $result.Summary.CompliancePercentage | Should -Be 0
+        }
+
+        It 'Totals analysis time across files as a TimeSpan' {
+            New-Fixture -Name 'A.ps1' -Content 'Write-Output 1'
+            New-Fixture -Name 'B.ps1' -Content 'Write-Output 2'
+            $result = Invoke-Compliance -Path $script:FixturePath
+
+            $result.Summary.TotalAnalysisTime | Should -BeOfType [TimeSpan]
+            $result.Summary.TotalAnalysisTime.Ticks | Should -BeGreaterThan 0
+        }
+
+        It 'Produces per-file results with distinct issue sets' {
+            New-Fixture -Name 'Clean.ps1' -Content 'Write-Output 1'
+            New-Fixture -Name 'BadVerb.ps1' -Content 'function Process-Thing { Write-Output 1 }'
+            $result = Invoke-Compliance -Path $script:FixturePath
+
+            # Regression: the analysis used to mutate the *previous* file's result,
+            # so issues leaked between files.
+            $bad = $result.FileResults | Where-Object FileName -eq 'BadVerb.ps1'
+            $clean = $result.FileResults | Where-Object FileName -eq 'Clean.ps1'
+            $bad.Issues.Count | Should -BeGreaterThan 0
+            $clean.Issues.Count | Should -Be 0
+        }
+
+        It 'Writes detailed output when -Detailed is supplied' {
+            New-Fixture -Name 'BadVerb.ps1' -Content 'function Process-Thing { Write-Output 1 }'
+
+            $output = & $script:ScriptPath -Path $script:FixturePath -PassThru -Detailed `
+                -InformationAction Continue 6>&1 | Out-String
+
+            $output | Should -Match 'BadVerb\.ps1'
+        }
+
+        It 'Skips test files when -ExcludeTests is supplied' {
+            New-Fixture -Name 'Regular.ps1' -Content 'Write-Output 1'
+            New-Fixture -Name 'Thing.Tests.ps1' -Content 'Write-Output 2'
+
+            $withTests = Invoke-Compliance -Path $script:FixturePath
+            $withoutTests = Invoke-Compliance -Path $script:FixturePath -Extra @{ ExcludeTests = $true }
+
+            $withTests.TotalFiles | Should -Be 2
+            $withoutTests.TotalFiles | Should -BeLessThan $withTests.TotalFiles
+        }
+    }
+
+    Context 'Additional output formats' {
+
+        It 'Writes an XML report' {
+            New-Fixture -Name 'Sample.ps1' -Content 'Write-Output 1'
+            $out = Join-Path $script:FixturePath 'report.xml'
+
+            Invoke-Compliance -Path $script:FixturePath -Extra @{ OutputFormat = 'XML'; OutputPath = $out } | Out-Null
+
+            $out | Should -Exist
+            (Get-Item $out).Length | Should -BeGreaterThan 0
+        }
+
+        It 'Writes an HTML report' {
+            New-Fixture -Name 'Sample.ps1' -Content 'Write-Output 1'
+            $out = Join-Path $script:FixturePath 'report.html'
+
+            Invoke-Compliance -Path $script:FixturePath -Extra @{ OutputFormat = 'HTML'; OutputPath = $out } | Out-Null
+
+            $out | Should -Exist
+            Get-Content $out -Raw | Should -Match '<html'
+        }
+    }
+}


### PR DESCRIPTION
Adds 43 tests covering the two `Tools/` scripts, which previously had none, and fixes the defects
those tests exposed.

## Coverage was measuring the wrong code

The reported figure of 22.77% was not a reflection of test quality. Of the 448 commands it measured,
197 were module templates — scaffolding intended to be copied and filled in, where a test would
assert against a placeholder. The single file that had tests was already at 98.1%.

The intentional anti-pattern examples were not a factor: `Test-QualityGates.ps1` was already excluded
by the old filename filter.

The actual gap was that neither shipped tool had any tests, and one of them was not being measured at
all.

## Testability changes

Two changes were required before the scripts could be tested in-process:

- `Test-StandardsCompliance.ps1` called `exit` unconditionally in its `end` block, terminating the
  host. No caller could retrieve the results object, and the `return $results` written below the
  exits was unreachable. A `-PassThru` switch now returns the object and skips the exit. Default CLI
  behaviour is unchanged.
- `Install-CopilotStandards.ps1` printed the VS Code settings deprecated in 1.102 on completion.
  #12 corrected this guidance in the README but not in the tool. A test now asserts it does not
  return.

## Defects found by the new tests

13 of 15 tests failed on first run against three defects in `Test-StandardsCompliance.ps1`, none of
which had been executed before.

**Analysis mutated the wrong object.** The per-file analysis ran inside the hashtable initializer
that defines `$fileResult`, assigned to its `AnalysisTime` key, while mutating `$fileResult.Issues`:

```powershell
$fileResult = @{
    Issues = @()
    AnalysisTime = Measure-Command {
        $fileResult.Issues += $fileAnalysisResults   # $fileResult does not exist yet
    }
}
```

The first file threw *"property 'Issues' cannot be found"*. Subsequent files were worse: `$fileResult`
still held the previous file's result, so issues leaked between files without error. The object is now
constructed before the analysis runs, and a regression test asserts per-file issue sets stay distinct.

**`Summary.TotalAnalysisTime` aborted every run.** It summed `TimeSpan` values with
`Measure-Object -Sum`, which rejects non-numeric input (*"Input object 00:00:00.13 is not numeric"*).
With `$ErrorActionPreference = 'Stop'` this failed the entire analysis, so the tool did not complete
for any input. It now sums ticks and rebuilds the `TimeSpan`.

**Two results objects were emitted.** The empty-directory path returned `$results` from `process`
while `end` returned it as well.

## Gate changes

File classification no longer uses a `*test*` name filter. `Test-` is an approved PowerShell verb, so
that filter cannot distinguish a test file from a tool named with the verb, and it excluded
`Test-StandardsCompliance.ps1` from analysis entirely. Test files are now `*.Tests.ps1` or anything
under a `Tests` directory. Files that intentionally demonstrate violations are declared explicitly:

```powershell
$demonstrationFiles = @('Test-QualityGates.ps1')
```

`CodeCoverage.Path` is now scoped to `Tools/*.ps1` — the code this repository ships and executes.
Templates and documentation examples remain covered by PSScriptAnalyzer and the example test suite.

## Additional changes

- Two emoji in tool output replaced with `[PASS]`/`[FAIL]`, clearing
  `PSUseBOMForUnicodeEncodedFile` and matching the repository's own rule against emoji in generated
  output.
- `coverage.xml`, `TestResults/` and `Tests/Results/` added to `.gitignore`. These were already
  written into the `.gitignore` that `Install-CopilotStandards.ps1` generates for consumers, but were
  absent from this repository's own.

## Results

| | Before | After |
|---|---|---|
| Tests | 35 | 78 |
| `Tools/` scripts with tests | 0 of 2 | 2 of 2 |
| Coverage | 22.77% (templates in denominator) | 88.33% (`Tools/`) |
| Analyzer errors / warnings in production files | 0 / 1 | 0 / 0 |

## Out of scope

The 80% coverage threshold remains warn-only; the workflow reports below-threshold coverage without
failing. Now that the measurement is meaningful, enforcing it would catch regressions, but that is a
policy change rather than a defect fix and is left for a separate decision.
