### PR TITLE
docs(prompts): align prompt guidance with the 7.6 baseline

### DIFF
--- a/.github/prompts/code-analysis.prompt.md
+++ b/.github/prompts/code-analysis.prompt.md
@@ -32,7 +32,8 @@ ${selection}
 **3. Performance Patterns ✅**
 
 - Context-aware string operations (simple vs complex)
-- Efficient collection handling (avoid array += in loops)
+- Collection handling: flag `+=` only where the declared target is below 7.5, in which it is still
+  O(n²), or where the loop is unbounded. PowerShell 7.5 optimised it. Never suggest `ArrayList`
 - Appropriate use of pipeline vs loops
 - Memory-conscious patterns for large datasets
 

--- a/.github/prompts/create-test.prompt.md
+++ b/.github/prompts/create-test.prompt.md
@@ -23,7 +23,8 @@ ${selection}
 
 **1. Modern Test Patterns ✅**
 
-- Use Pester 6.x syntax and features (Windows PowerShell 5.1 or PowerShell 7.4+)
+- Use Pester 6.x syntax and features. Pester 6 requires Windows PowerShell 5.1 or PowerShell 7.4+;
+  target 7.6 (LTS) for new work, as 7.4 and 7.5 reach end of support on 10-Nov-2026
 - Prefer the `Should-*` assertions (dash, no space) for new test files; classic
   `Should -Be` remains supported for existing suites
 - Make every test file self-contained: Pester 6 discovers and runs one file at a time,

--- a/.github/prompts/optimize-performance.prompt.md
+++ b/.github/prompts/optimize-performance.prompt.md
@@ -27,7 +27,8 @@ ${selection}
 4. **Algorithm Complexity**: Identify O(n²) operations, inefficient filtering and searching, redundant
    work, and poor data structure choices
 5. **Resource Management**: COM objects, file handles, database connections, network call batching
-6. **Parallel Processing**: PowerShell 7+ ForEach-Object -Parallel opportunities
+6. **Parallel Processing**: `ForEach-Object -Parallel` opportunities (PowerShell 7.4+; 7.6 is the
+   current LTS - 7.0 through 7.3 are retired)
 
 **Deliverables:**
 

--- a/.github/prompts/validate-standards.prompt.md
+++ b/.github/prompts/validate-standards.prompt.md
@@ -17,7 +17,8 @@ ${selection}
 
 - **Tool Design**: Verify functions are reusable with parameter input and pipeline output
 - **Error Handling**: Check for -ErrorAction Stop usage and proper try/catch blocks
-- **Performance**: Identify array appending, string concatenation, and pipeline efficiency issues
+- **Performance**: String concatenation and pipeline efficiency. Flag `+=` only where the declared
+  target is below 7.5, in which it remains O(n²) - PowerShell 7.5 optimised it
 - **Security**: Validate PSCredential usage and input sanitization
 - **Modularity**: Assess function design and single responsibility principle
 


### PR DESCRIPTION
Aligns four prompt files with the version-conditional guidance introduced in #9.

## Cause

#9 changed the array-append rule from a blanket prohibition to a version-conditional one, updating
`copilot-instructions.md`, `powershell-version.instructions.md` and `PowerShell-Best-Practices.md`.
Four prompt files were not updated: the search at the time covered `ArrayList` mentions and
`${input:psVersion}` selectors, and the prose rules matched neither pattern.

## Contradiction this produced

Two of the four are analysis prompts. On code targeting 7.6, they instructed Copilot to report `+=`
as a performance defect — contradicting the standards supplied by the same repository.

| File | Previous | Now |
|---|---|---|
| `code-analysis.prompt.md` | "avoid array `+=` in loops" | Flags `+=` only where the declared target is below 7.5, or the loop is unbounded; states not to suggest `ArrayList` |
| `validate-standards.prompt.md` | "Identify array appending … issues" | Same condition applied |

## Version references tightened

| File | Previous | Now |
|---|---|---|
| `create-test.prompt.md` | "Windows PowerShell 5.1 or PowerShell 7.4+" | Retains Pester 6's actual floor, and names 7.6 as the target for new work since 7.4 and 7.5 reach end of support on 10-Nov-2026 |
| `optimize-performance.prompt.md` | "PowerShell 7+ ForEach-Object -Parallel" | 7.4+, noting 7.6 is current LTS and 7.0–7.3 are retired |

## Reviewed and unchanged

The remaining six prompts require no change:

- `create-module` and `scaffold-project` are version-agnostic and inherit the 7.6 baseline through
  `copilot-instructions.md`, which VS Code applies automatically.
- `security-review`'s `SOX,GDPR,HIPAA,PCI-DSS` input selects which framework to review against, rather
  than claiming compliance, so the rewording in #12 does not apply.
- `new-function` and `performance-analysis` carry no stale guidance.
- No prompt needs to restate PSResourceGet or the `Microsoft.PowerShell.ThreadJob` rename, for the
  same inheritance reason.

## Verification

- Front matter valid on all 10 prompts; no cross-references to files that do not exist.
- The two prompts truncated in #10 (`code-analysis`, `optimize-performance`) end coherently.
- No `Install-Module`, `ArrayList` recommendation, or Pester 5 guidance remains in any prompt. The
  single surviving `ArrayList` occurrence is the instruction not to suggest it.
- markdownlint clean.
