### PR TITLE
docs: fix defects found auditing Documentation and Templates

### DIFF
--- a/Documentation/Examples/Configuration/DefaultConfiguration.psd1
+++ b/Documentation/Examples/Configuration/DefaultConfiguration.psd1
@@ -134,19 +134,19 @@
     # Integration Endpoints
     Integration = @{
         LoggingService = @{
-            Endpoint = 'https://logs.entravantage.com/api/v1/logs'
+            Endpoint = 'https://logs.yourorg.com/api/v1/logs'
             RequireAuthentication = $true
             TimeoutSeconds = 30
         }
 
         SecurityService = @{
-            Endpoint = 'https://security.entravantage.com/api/v1/audit'
+            Endpoint = 'https://security.yourorg.com/api/v1/audit'
             RequireAuthentication = $true
             TimeoutSeconds = 15
         }
 
         ComplianceService = @{
-            Endpoint = 'https://compliance.entravantage.com/api/v1/events'
+            Endpoint = 'https://compliance.yourorg.com/api/v1/events'
             RequireAuthentication = $true
             TimeoutSeconds = 45
         }

--- a/Documentation/Examples/ExampleModule.psd1
+++ b/Documentation/Examples/ExampleModule.psd1
@@ -6,8 +6,8 @@
 
     # Author Information
     Author = 'Jeffrey Stuhr'
-    CompanyName = 'EntraVantage'
-    Copyright = '(c) 2025 EntraVantage. All rights reserved.'
+    CompanyName = 'YourOrg'
+    Copyright = '(c) 2025 YourOrg. All rights reserved.'
     Description = 'Example enterprise PowerShell module demonstrating best practices for data processing, user management, and system administration with comprehensive security and compliance features.'
 
     # PowerShell Requirements
@@ -55,8 +55,8 @@
         PSData = @{
             # Module metadata for PowerShell Gallery
             Tags = @('Enterprise', 'PowerShell', 'Security', 'Compliance', 'UserManagement', 'Automation')
-            LicenseUri = 'https://github.com/EntraVantage/ExampleModule/blob/main/LICENSE'
-            ProjectUri = 'https://github.com/EntraVantage/ExampleModule'
+            LicenseUri = 'https://github.com/YourOrg/ExampleModule/blob/main/LICENSE'
+            ProjectUri = 'https://github.com/YourOrg/ExampleModule'
             ReleaseNotes = @'
 ## v1.2.0 Release Notes
 
@@ -88,15 +88,15 @@ For detailed changes, see CHANGELOG.md
 
         # Enterprise-specific metadata
         Enterprise = @{
-            SupportContact = 'powershell-support@entravantage.com'
-            DocumentationUri = 'https://docs.entravantage.com/powershell/examplemodule'
-            TroubleshootingUri = 'https://docs.entravantage.com/powershell/examplemodule/troubleshooting'
-            SecurityContact = 'security@entravantage.com'
+            SupportContact = 'powershell-support@yourorg.com'
+            DocumentationUri = 'https://docs.yourorg.com/powershell/examplemodule'
+            TroubleshootingUri = 'https://docs.yourorg.com/powershell/examplemodule/troubleshooting'
+            SecurityContact = 'security@yourorg.com'
             ComplianceFrameworks = @('SOX', 'GDPR', 'HIPAA', 'PCI-DSS')
-            QualityStandards = 'https://github.com/EntraVantage/PowerShell-Copilot-Standards'
+            QualityStandards = 'https://github.com/fadwen/Powershell-Copilot-Standards'
         }
     }
 
     # Help Info URI for updatable help
-    HelpInfoURI = 'https://docs.entravantage.com/powershell/examplemodule/help'
+    HelpInfoURI = 'https://docs.yourorg.com/powershell/examplemodule/help'
 }

--- a/Documentation/Examples/ExampleModule.psm1
+++ b/Documentation/Examples/ExampleModule.psm1
@@ -12,7 +12,7 @@
     Blog: https://www.techbyjeff.net
     LinkedIn: https://www.linkedin.com/in/jeffrey-stuhr-034214aa/
 
-    Quality Standards: https://github.com/EntraVantage/PowerShell-Copilot-Standards
+    Quality Standards: https://github.com/fadwen/Powershell-Copilot-Standards
 #>
 
 # Module initialization

--- a/Documentation/Examples/Module-Structure-Example/Classes/ExampleClass.ps1
+++ b/Documentation/Examples/Module-Structure-Example/Classes/ExampleClass.ps1
@@ -1,0 +1,32 @@
+class ExampleServiceResult {
+    <#
+        Demonstrates a PowerShell class used as a descriptive output type.
+
+        The standards discourage [OutputType([PSCustomObject])] because it tells a
+        caller nothing about the shape returned. A class names the shape, provides
+        IntelliSense, and lets behaviour live alongside the data.
+    #>
+
+    [string]$ServiceName
+    [string]$Environment
+    [ValidateSet('Healthy', 'Degraded', 'Unavailable')]
+    [string]$Status
+    [datetime]$CheckedAt
+    [guid]$CorrelationId
+
+    ExampleServiceResult([string]$ServiceName, [string]$Environment, [guid]$CorrelationId) {
+        $this.ServiceName = $ServiceName
+        $this.Environment = $Environment
+        $this.Status = 'Unavailable'
+        $this.CheckedAt = Get-Date
+        $this.CorrelationId = $CorrelationId
+    }
+
+    [bool] IsUsable() {
+        return $this.Status -in @('Healthy', 'Degraded')
+    }
+
+    [string] ToString() {
+        return "$($this.ServiceName) [$($this.Environment)]: $($this.Status)"
+    }
+}

--- a/Documentation/Examples/Module-Structure-Example/ModuleExample.psd1
+++ b/Documentation/Examples/Module-Structure-Example/ModuleExample.psd1
@@ -1,0 +1,34 @@
+@{
+    # Module Information
+    RootModule        = 'ModuleExample.psm1'
+    ModuleVersion     = '1.0.0'
+    GUID              = '8f2b1c9d-4e7a-4b3f-9c21-5d6e8a0f7b34'
+
+    # Author Information
+    Author            = 'Jeffrey Stuhr'
+    CompanyName       = 'YourOrg'
+    Copyright         = '(c) 2026 YourOrg. All rights reserved.'
+    Description       = 'Minimal reference module demonstrating the Public/Private/Classes layout and the export boundary described in the PowerShell Copilot Standards.'
+
+    # PowerShell Requirements
+    # 7.6 is the current LTS. Use '5.1' with @('Desktop','Core') only when Windows
+    # PowerShell support is an explicit requirement.
+    PowerShellVersion = '7.6'
+    CompatiblePSEditions = @('Core')
+
+    # Only the public surface is exported. Connect-ExampleService stays internal, so
+    # it can change without a breaking release.
+    FunctionsToExport = @('Get-ExampleData')
+    CmdletsToExport   = @()
+    VariablesToExport = @()
+    AliasesToExport   = @()
+
+    PrivateData = @{
+        PSData = @{
+            Tags       = @('PowerShell', 'Example', 'Standards', 'Reference')
+            ProjectUri = 'https://github.com/fadwen/Powershell-Copilot-Standards'
+            LicenseUri = 'https://github.com/fadwen/Powershell-Copilot-Standards/blob/main/LICENSE'
+            ReleaseNotes = 'Reference implementation accompanying the PowerShell Copilot Standards.'
+        }
+    }
+}

--- a/Documentation/Examples/Module-Structure-Example/ModuleExample.psm1
+++ b/Documentation/Examples/Module-Structure-Example/ModuleExample.psm1
@@ -1,0 +1,56 @@
+<#
+    ModuleExample root module.
+
+    Loads classes first, then private functions, then public ones - classes must be
+    available before any function that returns one is defined. Export is controlled
+    by the manifest's FunctionsToExport rather than a wildcard here, so the public
+    surface stays explicit.
+
+    Quality Standards: https://github.com/fadwen/Powershell-Copilot-Standards
+#>
+
+$ErrorActionPreference = 'Stop'
+
+#region Classes
+# Classes load first: Get-ExampleData returns an ExampleServiceResult, so the type
+# must exist before that function is dot-sourced.
+$ClassFiles = Get-ChildItem -Path "$PSScriptRoot/Classes/*.ps1" -ErrorAction SilentlyContinue
+foreach ($ClassFile in $ClassFiles) {
+    try {
+        . $ClassFile.FullName
+        Write-Verbose "Loaded class: $($ClassFile.BaseName)"
+    }
+    catch {
+        throw "Failed to load class $($ClassFile.BaseName): $($_.Exception.Message)"
+    }
+}
+#endregion
+
+#region Private Functions
+# Internal helpers - deliberately not exported by the manifest.
+$PrivateFunctions = Get-ChildItem -Path "$PSScriptRoot/Private/*.ps1" -ErrorAction SilentlyContinue
+foreach ($Function in $PrivateFunctions) {
+    try {
+        . $Function.FullName
+        Write-Verbose "Loaded private function: $($Function.BaseName)"
+    }
+    catch {
+        throw "Failed to load private function $($Function.BaseName): $($_.Exception.Message)"
+    }
+}
+#endregion
+
+#region Public Functions
+$PublicFunctions = Get-ChildItem -Path "$PSScriptRoot/Public/*.ps1" -ErrorAction SilentlyContinue
+foreach ($Function in $PublicFunctions) {
+    try {
+        . $Function.FullName
+        Write-Verbose "Loaded public function: $($Function.BaseName)"
+    }
+    catch {
+        throw "Failed to load public function $($Function.BaseName): $($_.Exception.Message)"
+    }
+}
+#endregion
+
+Write-Verbose "ModuleExample loaded: $($PublicFunctions.Count) public, $($PrivateFunctions.Count) private"

--- a/Documentation/Examples/Module-Structure-Example/Private/Connect-ExampleService.ps1
+++ b/Documentation/Examples/Module-Structure-Example/Private/Connect-ExampleService.ps1
@@ -1,0 +1,58 @@
+function Connect-ExampleService {
+    <#
+    .SYNOPSIS
+        Opens a session against the example backing service.
+
+    .DESCRIPTION
+        Private helper, not exported by the manifest. Demonstrates the boundary the
+        standards draw between internal and public surface: callers depend on
+        Get-ExampleData, so this can change shape without a breaking release.
+
+        Returns a session descriptor the public function passes back in. There is no
+        real service behind it; the sleep stands in for connection latency.
+
+    .PARAMETER Environment
+        Target environment for the connection.
+
+    .PARAMETER CorrelationId
+        Correlation identifier propagated from the caller so a single operation can
+        be traced across functions.
+
+    .EXAMPLE
+        PS> $session = Connect-ExampleService -Environment 'Test' -CorrelationId $id
+
+        DESCRIPTION: Opens a session against the test environment.
+        OUTPUT: A hashtable describing the session.
+        USE CASE: Called by Get-ExampleData before querying.
+
+    .NOTES
+        Author: Jeffrey Stuhr
+        Blog: https://www.techbyjeff.net
+    #>
+
+    [CmdletBinding()]
+    [OutputType([hashtable])]
+    param(
+        [Parameter(Mandatory)]
+        [ValidateSet('Development', 'Test', 'Production')]
+        [string]$Environment,
+
+        [Parameter(Mandatory)]
+        [guid]$CorrelationId
+    )
+
+    process {
+        Write-Verbose "Connecting to $Environment - CorrelationId: $CorrelationId"
+
+        # Stand-in for real connection latency; a genuine implementation would open
+        # a session here and throw on failure so the caller's catch block runs.
+        Start-Sleep -Milliseconds 20
+
+        @{
+            Environment   = $Environment
+            CorrelationId = $CorrelationId
+            ConnectedAt   = Get-Date
+            Endpoint      = "https://example-service.yourorg.com/$($Environment.ToLower())"
+        }
+    }
+}

--- a/Documentation/Examples/Module-Structure-Example/Public/Get-ExampleData.ps1
+++ b/Documentation/Examples/Module-Structure-Example/Public/Get-ExampleData.ps1
@@ -1,0 +1,96 @@
+function Get-ExampleData {
+    <#
+    .SYNOPSIS
+        Retrieves service status for one or more services.
+
+    .DESCRIPTION
+        The exported surface of this example module. Demonstrates the patterns the
+        standards require:
+
+        - An approved verb, with a descriptive [OutputType] rather than PSCustomObject
+        - Pipeline input, so the function composes
+        - A correlation ID generated once and carried through every call
+        - $_ in the catch block, and per-item failure that does not abort the batch
+
+    .PARAMETER ServiceName
+        One or more service names to query. Accepts pipeline input.
+
+    .PARAMETER Environment
+        Environment to query. Defaults to Development so the example is safe to run.
+
+    .PARAMETER CorrelationId
+        Optional correlation identifier. One is generated when not supplied, which is
+        why the parameter carries no ValidateNotNullOrEmpty - it is never empty.
+
+    .EXAMPLE
+        PS> Get-ExampleData -ServiceName 'Billing'
+
+        DESCRIPTION: Queries a single service in the default environment.
+        OUTPUT: One ExampleServiceResult.
+        USE CASE: Ad-hoc check of a single service.
+
+    .EXAMPLE
+        PS> 'Billing', 'Identity' | Get-ExampleData -Environment Test
+
+        DESCRIPTION: Queries two services via the pipeline.
+        OUTPUT: One ExampleServiceResult per service.
+        USE CASE: Batch check where one failure must not stop the rest.
+
+    .OUTPUTS
+        ExampleServiceResult. One object per service queried.
+
+    .NOTES
+        Author: Jeffrey Stuhr
+        Blog: https://www.techbyjeff.net
+        LinkedIn: https://www.linkedin.com/in/jeffrey-stuhr-034214aa/
+
+        TROUBLESHOOTING:
+        - Connection issues: .\Troubleshooting\Common\Function-Issues.md
+    #>
+
+    [CmdletBinding()]
+    [OutputType('ExampleServiceResult')]
+    param(
+        [Parameter(Mandatory, ValueFromPipeline, ValueFromPipelineByPropertyName)]
+        [string[]]$ServiceName,
+
+        [Parameter()]
+        [ValidateSet('Development', 'Test', 'Production')]
+        [string]$Environment = 'Development',
+
+        [Parameter()]
+        [guid]$CorrelationId = [guid]::NewGuid()
+    )
+
+    begin {
+        Write-Verbose "Starting $($MyInvocation.MyCommand.Name) - CorrelationId: $CorrelationId"
+        $session = Connect-ExampleService -Environment $Environment -CorrelationId $CorrelationId
+        $failureCount = 0
+    }
+
+    process {
+        foreach ($name in $ServiceName) {
+            try {
+                Write-Verbose "Querying $name via $($session.Endpoint)"
+
+                $result = [ExampleServiceResult]::new($name, $Environment, $CorrelationId)
+
+                # Stands in for a real query. Production is treated as degraded purely
+                # to show a non-uniform result set.
+                $result.Status = if ($Environment -eq 'Production') { 'Degraded' } else { 'Healthy' }
+
+                $result
+            }
+            catch {
+                # $_ in the catch block, per the standards - not $Error[0]
+                $failureCount++
+                Write-Error "Failed to query '$name': $($_.Exception.Message) (CorrelationId: $CorrelationId)"
+                continue
+            }
+        }
+    }
+
+    end {
+        Write-Verbose "Completed with $failureCount failure(s) - CorrelationId: $CorrelationId"
+    }
+}

--- a/Documentation/Examples/Module-Structure-Example/README.md
+++ b/Documentation/Examples/Module-Structure-Example/README.md
@@ -1,1 +1,62 @@
+# Module Structure Example
 
+A minimal but working module showing the layout the standards expect, and - more importantly - the
+export boundary that layout exists to create.
+
+Small enough to read in one sitting. For a fuller starting point to copy, use
+[Templates/Powershell-Module](../../../Templates/Powershell-Module/).
+
+## Layout
+
+```text
+Module-Structure-Example/
+├── ModuleExample.psd1     # Manifest. Declares the public surface explicitly
+├── ModuleExample.psm1     # Loader. Classes, then private, then public
+├── Classes/
+│   └── ExampleClass.ps1   # ExampleServiceResult - a named output type
+├── Private/
+│   └── Connect-ExampleService.ps1   # Internal, never exported
+└── Public/
+    └── Get-ExampleData.ps1          # The only exported function
+```
+
+## Why the folders exist
+
+**Load order is not arbitrary.** `ModuleExample.psm1` loads `Classes/` first, because
+`Get-ExampleData` returns an `ExampleServiceResult` and the type must exist before the function
+referencing it is defined. Private functions load next, so public functions can call them.
+
+**The manifest controls export, not the loader.** `FunctionsToExport = @('Get-ExampleData')` names
+the public surface. `Connect-ExampleService` is dot-sourced and callable inside the module, but is
+never exported - so its signature can change without a breaking release. A wildcard export would
+remove that freedom and slow module autoloading.
+
+**A class replaces `[PSCustomObject]`.** `[OutputType('ExampleServiceResult')]` tells a caller what
+they receive and gives them IntelliSense. The standards discourage `[OutputType([PSCustomObject])]`
+because it communicates nothing.
+
+## Patterns demonstrated
+
+| Pattern | Where |
+|---|---|
+| Approved verb, descriptive `[OutputType]` | `Public/Get-ExampleData.ps1` |
+| Pipeline input via `ValueFromPipeline` | `Public/Get-ExampleData.ps1` |
+| Correlation ID generated once, passed through | All three files |
+| `$_` in `catch`, not `$Error[0]` | `Public/Get-ExampleData.ps1` |
+| Per-item failure that does not abort the batch | `Public/Get-ExampleData.ps1` |
+| Class with validation and behaviour | `Classes/ExampleClass.ps1` |
+
+## Trying it
+
+```powershell
+Import-Module ./ModuleExample.psd1 -Force
+
+Get-ExampleData -ServiceName 'Billing'
+'Billing', 'Identity' | Get-ExampleData -Environment Test -Verbose
+
+# The private helper is deliberately not available
+Get-Command Connect-ExampleService -ErrorAction SilentlyContinue   # returns nothing
+```
+
+There is no real service behind this module. `Connect-ExampleService` sleeps briefly to stand in for
+connection latency, and status is derived from the environment so the result set is not uniform.

--- a/Documentation/Examples/README.md
+++ b/Documentation/Examples/README.md
@@ -4,7 +4,7 @@
 
 ExampleModule demonstrates enterprise-grade PowerShell development following established community standards and
 organizational requirements. This module serves as both a functional tool and a reference implementation for the
-[PowerShell Copilot Standards](https://github.com/EntraVantage/PowerShell-Copilot-Standards).
+[PowerShell Copilot Standards](https://github.com/fadwen/Powershell-Copilot-Standards).
 
 ## Features
 
@@ -27,7 +27,7 @@ Install-PSResource -Name ExampleModule -Repository PSGallery -Scope CurrentUser 
 
 ```powershell
 # Clone the repository
-git clone https://github.com/EntraVantage/ExampleModule.git
+git clone https://github.com/YourOrg/ExampleModule.git
 
 # Import the module
 Import-Module .\ExampleModule\ExampleModule.psd1
@@ -123,7 +123,7 @@ All functions support enterprise security requirements:
 
 ## Quality Standards
 
-This module follows the [PowerShell Copilot Standards](https://github.com/EntraVantage/PowerShell-Copilot-Standards)
+This module follows the [PowerShell Copilot Standards](https://github.com/fadwen/Powershell-Copilot-Standards)
 including:
 
 ### Code Quality Requirements
@@ -208,7 +208,7 @@ The main branch is protected with required status checks:
 
 ```powershell
 # Clone the repository
-git clone https://github.com/EntraVantage/ExampleModule.git
+git clone https://github.com/YourOrg/ExampleModule.git
 cd ExampleModule
 
 # Create feature branch
@@ -257,7 +257,7 @@ Get-AuditLog -Category "Compliance" -TimeRange (Get-Date).AddDays(-7)
 
 ### Support Resources
 
-- **Documentation**: [Enterprise PowerShell Docs](https://docs.entravantage.com/powershell)
+- **Documentation**: [Enterprise PowerShell Docs](https://docs.yourorg.com/powershell)
 - **Troubleshooting**: [Common Issues Guide](./Troubleshooting/README.md)
 - **Security**: [Security Configuration Guide](./Documentation/Security-Configuration.md)
 - **Performance**: [Performance Optimization Guide](./Documentation/Performance-Optimization.md)
@@ -273,7 +273,7 @@ See [CHANGELOG.md](CHANGELOG.md) for detailed version history and breaking chang
 ---
 
 **Quality Standards**: This module follows
-[PowerShell Copilot Standards](https://github.com/EntraVantage/PowerShell-Copilot-Standards) for enterprise PowerShell
+[PowerShell Copilot Standards](https://github.com/fadwen/Powershell-Copilot-Standards) for enterprise PowerShell
 development.
 
-**Support**: For enterprise support, contact powershell-support@entravantage.com
+**Support**: For enterprise support, contact powershell-support@yourorg.com

--- a/Documentation/Implementation-Guide.md
+++ b/Documentation/Implementation-Guide.md
@@ -9,15 +9,18 @@
 - PowerShell 7.6 (LTS) recommended; Windows PowerShell 5.1 supported for legacy estates
 - Git for version control
 
-### Step 1: Enable Copilot Instructions in VS Code
+### Step 1: Confirm VS Code Picks Up the Instructions
 
-Add to your VS Code `settings.json`:
+No configuration is required. Current VS Code loads `.github/copilot-instructions.md`
+automatically, applies `.github/instructions/*.instructions.md` to files matching their `applyTo`
+glob, and exposes `.github/prompts/*.prompt.md` as `/prompt-name` in Copilot Chat.
+
+Settings are only needed when these files live outside the default locations:
 
 ```json
 {
-  "chat.promptFiles": true,
-  "github.copilot.chat.codeGeneration.useInstructionFiles": true,
-  "github.copilot.chat.codeGeneration.instructions": []
+  "chat.instructionsFilesLocations": { ".github/instructions": true },
+  "chat.promptFilesLocations": { ".github/prompts": true }
 }
 ```
 
@@ -26,6 +29,10 @@ To open settings.json:
 1. Press `Ctrl+Shift+P` (Windows/Linux) or `Cmd+Shift+P` (Mac)
 2. Type "Preferences: Open Settings (JSON)"
 3. Add the settings above
+
+> Earlier guidance used `chat.promptFiles` and
+> `github.copilot.chat.codeGeneration.useInstructionFiles`. Settings-based instructions were
+> deprecated in VS Code 1.102 in favour of the file-based layout above.
 
 ### Step 2: Choose Implementation Method
 
@@ -101,7 +108,7 @@ Copilot will generate a complete enterprise-standard function with:
 - `/new-function` - Create new PowerShell function
 - `/security-review` - Analyze code for security issues
 - `/optimize-performance` - Improve code performance
-- `/create-tests` - Generate Pester test suite
+- `/create-test` - Generate Pester test suite
 
 ### Code Quality Tasks
 
@@ -143,9 +150,11 @@ Copilot will generate a complete enterprise-standard function with:
 
 **Copilot doesn't use instructions**
 
-- Verify `chat.promptFiles: true` in VS Code settings
-- Check that `.github/copilot-instructions.md` exists
-- Restart VS Code after adding settings
+- Check that `.github/copilot-instructions.md` exists at the workspace root
+- Confirm instruction files sit under `.github/instructions/` with an `applyTo` glob that matches
+  the file being edited
+- If the files live elsewhere, set `chat.instructionsFilesLocations` / `chat.promptFilesLocations`
+- Restart VS Code after moving or adding files
 
 **Prompts don't appear**
 

--- a/Templates/Powershell-Module/Classes/TemplateClass.ps1
+++ b/Templates/Powershell-Module/Classes/TemplateClass.ps1
@@ -1,0 +1,44 @@
+<#
+    Class template. Replace with the types your module needs, or delete this file if
+    it has none - ModuleName.psm1 tolerates an empty Classes folder.
+
+    Two ways to give output a descriptive name, both accepted by the standards:
+
+    1. A class, as below. Enforces shape, supports validation and methods, and gives
+       callers IntelliSense. Declare it as [OutputType('TemplateResult')].
+    2. A PSCustomObject carrying a PSTypeName, which Get-TemplateFunction uses.
+       Lighter, but nothing enforces the shape.
+
+    Either way the [OutputType] argument is QUOTED. [TemplateResult] is a .NET type
+    reference, and fails with "Unable to find type" unless the class has already been
+    loaded when the function is parsed.
+#>
+
+class TemplateResult {
+    [string]$Name
+    [ValidateSet('Success', 'Warning', 'Failed')]
+    [string]$Status
+    [datetime]$ProcessedAt
+    [guid]$CorrelationId
+    [string[]]$Messages
+
+    TemplateResult([string]$Name, [guid]$CorrelationId) {
+        $this.Name = $Name
+        $this.Status = 'Success'
+        $this.ProcessedAt = Get-Date
+        $this.CorrelationId = $CorrelationId
+        $this.Messages = @()
+    }
+
+    [void] AddMessage([string]$Message) {
+        $this.Messages += $Message
+    }
+
+    [bool] HasFailed() {
+        return $this.Status -eq 'Failed'
+    }
+
+    [string] ToString() {
+        return "$($this.Name): $($this.Status) ($($this.Messages.Count) message(s))"
+    }
+}

--- a/Templates/Powershell-Module/Public/Get-TemplateFunction.ps1
+++ b/Templates/Powershell-Module/Public/Get-TemplateFunction.ps1
@@ -31,7 +31,10 @@ function Get-TemplateFunction {
     ServiceProcessingResult. Returns processing results with status and data.
     #>
     [CmdletBinding()]
-    [OutputType([ServiceProcessingResult])]
+    # Quoted: the function returns a PSCustomObject carrying PSTypeName =
+    # 'ServiceProcessingResult'. [ServiceProcessingResult] would be a .NET type
+    # reference and fails with "Unable to find type".
+    [OutputType('ServiceProcessingResult')]
     param(
         [Parameter(Mandatory, ValueFromPipeline)]
         [ValidateNotNullOrEmpty()]

--- a/Templates/Powershell-Module/README.md
+++ b/Templates/Powershell-Module/README.md
@@ -12,7 +12,7 @@ performance, and maintainability.
 
 ```powershell
 # From PowerShell Gallery
-Install-Module ModuleName -Scope CurrentUser
+Install-PSResource ModuleName -Scope CurrentUser -TrustRepository
 
 # Import the module
 Import-Module ModuleName
@@ -39,7 +39,7 @@ Get-TemplateFunction -Name "ExampleItem"
 - ✅ Enterprise security controls and audit logging
 - ✅ Comprehensive error handling with correlation IDs
 - ✅ Performance optimization and monitoring
-- ✅ Cross-platform compatibility (PowerShell 7+)
+- ✅ Cross-platform compatibility (PowerShell 7.6 LTS; the manifest targets `Core`)
 - ✅ Integration with enterprise systems
 - ✅ Comprehensive Pester test coverage
 
@@ -66,4 +66,4 @@ For common issues and solutions, see:
 
 ## 📄 License
 
-See [LICENSE](../LICENSE) file for details.
+See [LICENSE](../../LICENSE) file for details.


### PR DESCRIPTION
Fixes defects found in a full audit of `Documentation/` and `Templates/` following #9–#14.

## Broken

### `Module-Structure-Example/` was entirely hollow

Six zero-byte files (`ModuleExample.psd1`, `.psm1`, `Public/`, `Private/`, `Classes/`) and a README
containing only a blank line. Git history shows they were created empty and never populated; nothing
in the repository referenced the directory. `ModuleExample.psd1` failed both
`Import-PowerShellDataFile` and `Test-ModuleManifest`.

Now a working module demonstrating the layout and, more usefully, the export boundary the layout
exists to create:

- Classes load before the functions that return them, because `Get-ExampleData` returns an
  `ExampleServiceResult`
- `FunctionsToExport` names the public surface, so `Connect-ExampleService` stays internal and can
  change without a breaking release
- `[OutputType('ExampleServiceResult')]` rather than `[PSCustomObject]`

Verified end to end: the manifest validates, the module imports, single and pipeline invocation both
work, the returned object is an `ExampleServiceResult`, and `Get-Command Connect-ExampleService`
returns nothing.

### Template declared a type that cannot resolve

`Templates/Powershell-Module/Public/Get-TemplateFunction.ps1` declared
`[OutputType([ServiceProcessingResult])]` — a .NET type reference that fails with *"Unable to find
type"* — while returning a `PSCustomObject` carrying `PSTypeName = 'ServiceProcessingResult'`. This
is the same defect fixed in #11 for `[OutputType([TestResult])]`. Now quoted.

`Classes/TemplateClass.ps1` was empty despite `ModuleName.psm1` dot-sourcing `Classes/*.ps1`, and
its siblings under `Public/` and `Private/` are fully written. It now holds a class showing both
ways to give output a descriptive name, and why the `[OutputType]` argument is quoted in each.

## Inconsistent

### Organisation naming

`Documentation/Examples/` hardcoded `EntraVantage` in 21 places — company name, copyright, support
addresses, and API endpoints — while `Templates/` used generic `YourOrg` / `docs.yourorg.com`
placeholders. Two of those references pointed at
`https://github.com/EntraVantage/PowerShell-Copilot-Standards`, that organisation's copy of this
repository.

`Documentation/Examples/` now follows the same placeholder convention as `Templates/`, and links
back to this repository resolve to `fadwen/Powershell-Copilot-Standards`.

### Stale guidance already corrected elsewhere

`Documentation/Implementation-Guide.md` still instructed users to set `chat.promptFiles` and
`github.copilot.chat.codeGeneration.useInstructionFiles`, deprecated in VS Code 1.102. #12 corrected
the README and #13 the installer; this file was missed. It also listed `/create-tests`, which does
not exist — the prompt is `create-test.prompt.md`.

`Templates/Powershell-Module/README.md`: `Install-Module` to `Install-PSResource`, "PowerShell 7+"
to 7.6 matching its own manifest, and the LICENSE link corrected from `../LICENSE` — which resolved
to a non-existent `Templates/LICENSE` — to `../../LICENSE`.

## Verification

| Check | Result |
|---|---|
| `.ps1` / `.psm1` parse | all clean |
| `.psd1` load | all clean (was 1 failure) |
| Zero-byte files | none (was 6) |
| PSScriptAnalyzer, 17 production files | 0 errors, 0 warnings |
| Pester | 78/78 |
| Coverage | 88.59% |
| markdownlint | clean |
| `/prompt` references | all resolve |

## Reviewed and left unchanged

Relative links in `Documentation/Examples/README.md` (`CHANGELOG.md`, `./Troubleshooting/`) and
`Templates/Powershell-Module/README.md` (`./Troubleshooting/Common/`) do not resolve within this
repository. Both files are sample READMEs intended to be copied into a consumer's project, where
`Install-CopilotStandards.ps1` creates those directories. The paths are correct in their destination
context.

Example tests use the classic `Should -Be` form rather than Pester 6 `Should-*`.
`pester.instructions.md` permits classic assertions for existing suites and prefers `Should-*` for
new files, so these are compliant, though they demonstrate the older style.
