### PR TITLE
test: migrate the test suite to Pester 6 Should-* assertions

### DIFF
--- a/Documentation/Examples/Test-QualityGates.Tests.ps1
+++ b/Documentation/Examples/Test-QualityGates.Tests.ps1
@@ -41,19 +41,21 @@ Describe "Test-QualityGates Function" -Tag "Unit", "QualityDemo" {
         }
 
         It "Should accept valid UserName parameter" {
-            { Test-QualityGates -UserName "testuser" } | Should -Not -Throw
+            # Pester 6 has no Should-NotThrow. Calling the code is the assertion -
+            # an unhandled exception fails the test.
+            Test-QualityGates -UserName "testuser"
         }
 
         It "Should handle empty ServerList gracefully" {
             $result = Test-QualityGates -UserName "testuser" -ServerList @()
-            $result | Should -Not -BeNullOrEmpty
-            $result.ServersProcessed | Should -Be 0
+            $result | Should-NotBeNull
+            $result.ServersProcessed | Should-Be 0
         }
 
         It "Should process multiple servers" {
             $servers = @("server1", "server2", "server3")
             $result = Test-QualityGates -UserName "testuser" -ServerList $servers
-            $result.ServersProcessed | Should -Be 3
+            $result.ServersProcessed | Should-Be 3
         }
     }
 
@@ -66,7 +68,10 @@ Describe "Test-QualityGates Function" -Tag "Unit", "QualityDemo" {
         }
 
         It "Should handle user not found errors" {
-            { Test-QualityGates -UserName "nonexistentuser" } | Should -Throw "*User not found*"
+            # -ExceptionMessage matches with wildcards, so the leading/trailing * are
+            # needed for a substring match - unlike classic Should -Throw.
+            { Test-QualityGates -UserName "nonexistentuser" } |
+                Should-Throw -ExceptionMessage '*User not found*'
         }
     }
 
@@ -85,20 +90,20 @@ Describe "Test-QualityGates Function" -Tag "Unit", "QualityDemo" {
         It "Should return PSCustomObject with required properties" {
             $result = Test-QualityGates -UserName "testuser" -ServerList @("server1")
 
-            $result | Should -BeOfType [PSCustomObject]
-            $result.UserName | Should -Be "testuser"
-            $result.ServersProcessed | Should -Be 1
-            $result.ProcessedAt | Should -BeOfType [DateTime]
+            $result | Should-NotBeNull
+            $result.UserName | Should-Be "testuser"
+            $result.ServersProcessed | Should-Be 1
+            $result.ProcessedAt | Should-HaveType ([datetime])
         }
 
         It "Should include log size information" {
             $result = Test-QualityGates -UserName "testuser"
-            $result.LogSize | Should -BeGreaterThan 0
+            $result.LogSize | Should-BeGreaterThan 0
         }
 
         It "Should include database query information" {
             $result = Test-QualityGates -UserName "testuser"
-            $result.DatabaseQuery | Should -Match "SELECT.*FROM.*Users"
+            $result.DatabaseQuery | Should-MatchString "SELECT.*FROM.*Users"
         }
     }
 }
@@ -107,60 +112,62 @@ Describe "Get-TestResults Function" -Tag "Unit", "GoodExample" {
 
     Context "Proper Implementation Validation" {
         It "Should use approved PowerShell verb" {
-            # Verify the function name uses an approved verb
+            # Should -BeIn has no 1:1 replacement; Should-Any expresses the same check
             $approvedVerbs = Get-Verb | Select-Object -ExpandProperty Verb
-            "Get" | Should -BeIn $approvedVerbs
+            $approvedVerbs | Should-Any { $_ -eq 'Get' }
         }
 
         It "Should accept mandatory TestName parameter" {
-            { Get-TestResults -TestName "SecurityTest" } | Should -Not -Throw
+            Get-TestResults -TestName "SecurityTest"
         }
 
         It "Should generate correlation ID automatically" {
             $result = Get-TestResults -TestName "AutoTest"
-            $result.CorrelationId | Should -Not -BeNullOrEmpty
-            $result.CorrelationId | Should -Match "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
+            $result.CorrelationId | Should-NotBeEmptyString
+            $result.CorrelationId |
+                Should-MatchString "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
         }
 
         It "Should handle empty test name appropriately" {
             # A Mandatory [string] rejects '' during binding, before the body runs,
             # so the message comes from PowerShell - not the function's own guard.
-            { Get-TestResults -TestName "" } | Should -Throw "*empty string*"
+            { Get-TestResults -TestName "" } | Should-Throw -ExceptionMessage '*empty string*'
         }
 
         It "Should handle whitespace-only test name" {
             # Whitespace binds fine, so the function's own validation produces this one
-            { Get-TestResults -TestName "   " } | Should -Throw "*cannot be empty or whitespace*"
+            { Get-TestResults -TestName "   " } |
+                Should-Throw -ExceptionMessage '*cannot be empty or whitespace*'
         }
 
         It "Should return properly typed result" {
             $result = Get-TestResults -TestName "TypeTest"
             # PSTypeName is consumed when constructing the object; it sets the type
             # name rather than remaining as a readable property.
-            $result.PSObject.TypeNames[0] | Should -Be "TestResult"
-            $result.Status | Should -Be "Passed"
+            $result.PSObject.TypeNames[0] | Should-Be "TestResult"
+            $result.Status | Should-Be "Passed"
         }
 
         It "Should include all required properties" {
             $result = Get-TestResults -TestName "PropertyTest"
 
-            $result.TestName | Should -Be "PropertyTest"
-            $result.Status | Should -Not -BeNullOrEmpty
-            $result.CorrelationId | Should -Not -BeNullOrEmpty
-            $result.ExecutedAt | Should -BeOfType [DateTime]
+            $result.TestName | Should-Be "PropertyTest"
+            $result.Status | Should-NotBeEmptyString
+            $result.CorrelationId | Should-NotBeEmptyString
+            $result.ExecutedAt | Should-HaveType ([datetime])
         }
     }
 
     Context "Parameter Validation Best Practices" {
         It "Should trim whitespace from TestName parameter" {
             $result = Get-TestResults -TestName "  TrimTest  "
-            $result.TestName | Should -Be "TrimTest"
+            $result.TestName | Should-Be "TrimTest"
         }
 
         It "Should accept custom correlation ID" {
             $customId = [System.Guid]::NewGuid().ToString()
             $result = Get-TestResults -TestName "CustomIdTest" -CorrelationId $customId
-            $result.CorrelationId | Should -Be $customId
+            $result.CorrelationId | Should-Be $customId
         }
     }
 }
@@ -171,14 +178,14 @@ Describe "Process-TestData Function" -Tag "Unit", "QualityIssue" {
         It "Should use non-approved verb (demonstrates quality issue)" {
             # This test documents the quality issue for educational purposes
             $approvedVerbs = Get-Verb | Select-Object -ExpandProperty Verb
-            "Process" | Should -Not -BeIn $approvedVerbs
+            $approvedVerbs | Should-All { $_ -ne 'Process' }
         }
     }
 
     Context "Basic Functionality" {
         It "Should process simple data" {
             $result = Process-TestData -Data "test"
-            $result | Should -Be "Processed: test"
+            $result | Should-Be "Processed: test"
         }
     }
 }

--- a/Documentation/Examples/Testing-Examples/Basic-Function.Tests.ps1
+++ b/Documentation/Examples/Testing-Examples/Basic-Function.Tests.ps1
@@ -67,7 +67,7 @@ Describe "Get-BasicServerInfo" -Tag "Unit", "Example" {
             param($ComputerName, $Expected)
             
             # This should not throw
-            { Get-BasicServerInfo -ComputerName $ComputerName -WhatIf } | Should -Not -Throw
+            Get-BasicServerInfo -ComputerName $ComputerName -WhatIf
         }
         
         # Expected messages are the ones PowerShell's validation attributes actually
@@ -80,14 +80,14 @@ Describe "Get-BasicServerInfo" -Tag "Unit", "Example" {
         ) {
             param($InvalidName, $ExpectedError)
             
-            { Get-BasicServerInfo -ComputerName $InvalidName } | Should -Throw $ExpectedError
+            { Get-BasicServerInfo -ComputerName $InvalidName } | Should-Throw -ExceptionMessage $ExpectedError
         }
         
         It "Should support pipeline input" {
             $computerNames = @('SERVER01', 'SERVER02')
             
             # This should not throw and should accept pipeline input
-            { $computerNames | Get-BasicServerInfo -WhatIf } | Should -Not -Throw
+            $computerNames | Get-BasicServerInfo -WhatIf
         }
     }
     
@@ -97,29 +97,29 @@ Describe "Get-BasicServerInfo" -Tag "Unit", "Example" {
             $result = Get-BasicServerInfo -ComputerName 'MOCKSERVER'
             
             # Verify object structure
-            $result | Should -Not -BeNullOrEmpty
-            $result | Should -BeOfType [PSCustomObject]
+            $result | Should-NotBeNull
+            $result | Should-NotBeNull
             
             # Verify required properties
-            $result.ComputerName | Should -Be 'MOCKSERVER'
-            $result.OperatingSystem | Should -Be 'Microsoft Windows Server 2019'
-            $result.TotalMemoryGB | Should -Be 16
-            $result.CorrelationId | Should -Not -BeNullOrEmpty
+            $result.ComputerName | Should-Be 'MOCKSERVER'
+            $result.OperatingSystem | Should-Be 'Microsoft Windows Server 2019'
+            $result.TotalMemoryGB | Should-Be 16
+            $result.CorrelationId | Should-NotBeNull
         }
         
         It "Should include services when IncludeServices switch is used" {
             $result = Get-BasicServerInfo -ComputerName 'MOCKSERVER' -IncludeServices
             
-            $result.RunningServices | Should -Not -BeNullOrEmpty
-            $result.RunningServiceCount | Should -Be 2
-            $result.RunningServices[0].Name | Should -Be 'Spooler'
+            $result.RunningServices | Should-NotBeNull
+            $result.RunningServiceCount | Should-Be 2
+            $result.RunningServices[0].Name | Should-Be 'Spooler'
         }
         
         It "Should calculate uptime correctly" {
             $result = Get-BasicServerInfo -ComputerName 'MOCKSERVER'
             
-            $result.UptimeDays | Should -BeGreaterThan 4.9
-            $result.UptimeDays | Should -BeLessThan 5.1
+            $result.UptimeDays | Should-BeGreaterThan 4.9
+            $result.UptimeDays | Should-BeLessThan 5.1
         }
     }
     
@@ -146,15 +146,15 @@ Describe "Get-BasicServerInfo" -Tag "Unit", "Example" {
         }
 
         It "Should handle connection failures gracefully" {
-            { Get-BasicServerInfo -ComputerName 'OFFLINE' -ErrorAction SilentlyContinue } | Should -Not -Throw
+            Get-BasicServerInfo -ComputerName 'OFFLINE' -ErrorAction SilentlyContinue
         }
 
         It "Should continue processing other computers when one fails" {
             $results = Get-BasicServerInfo -ComputerName @('MOCKSERVER', 'OFFLINE') -ErrorAction SilentlyContinue
 
             # Should get one successful result despite one failure
-            $results | Should -Not -BeNullOrEmpty
-            $results.ComputerName | Should -Contain 'MOCKSERVER'
+            $results | Should-NotBeNull
+            $results.ComputerName | Should-ContainCollection 'MOCKSERVER'
         }
     }
     
@@ -165,15 +165,15 @@ Describe "Get-BasicServerInfo" -Tag "Unit", "Example" {
             Get-BasicServerInfo -ComputerName 'MOCKSERVER' | Out-Null
             
             $stopwatch.Stop()
-            $stopwatch.ElapsedMilliseconds | Should -BeLessThan 5000  # 5 seconds max for mocked operations
+            $stopwatch.ElapsedMilliseconds | Should-BeLessThan 5000  # 5 seconds max for mocked operations
         }
         
         It "Should include performance metrics in output" {
             $result = Get-BasicServerInfo -ComputerName 'MOCKSERVER'
             
-            $result.QueryTime | Should -Not -BeNullOrEmpty
-            $result.QueryDurationMs | Should -BeGreaterThan 0
-            $result.CorrelationId | Should -Not -BeNullOrEmpty
+            $result.QueryTime | Should-NotBeNull
+            $result.QueryDurationMs | Should-BeGreaterThan 0
+            $result.CorrelationId | Should-NotBeNull
         }
     }
 }

--- a/Tools/Tests/Install-CopilotStandards.Tests.ps1
+++ b/Tools/Tests/Install-CopilotStandards.Tests.ps1
@@ -24,24 +24,24 @@ Describe 'Install-CopilotStandards' -Tag 'Unit', 'Tools' {
         It 'Rejects a ProjectPath that does not exist' {
             $missing = Join-Path $script:ProjectPath 'no-such-directory'
             { & $script:ScriptPath -ProjectPath $missing -InformationAction SilentlyContinue } |
-                Should -Throw '*does not exist*'
+                Should-Throw -ExceptionMessage '*does not exist*'
         }
 
         It 'Rejects a ProjectPath that is a file rather than a directory' {
             $file = Join-Path $script:ProjectPath 'a-file.txt'
             Set-Content -Path $file -Value 'not a directory'
             { & $script:ScriptPath -ProjectPath $file -InformationAction SilentlyContinue } |
-                Should -Throw '*does not exist*'
+                Should-Throw -ExceptionMessage '*does not exist*'
         }
 
         It 'Rejects an unknown StandardsType' {
             { & $script:ScriptPath -ProjectPath $script:ProjectPath -StandardsType 'NotAType' -InformationAction SilentlyContinue } |
-                Should -Throw '*ValidateSet*'
+                Should-Throw -ExceptionMessage '*ValidateSet*'
         }
 
         It 'Rejects an unknown LinkType' {
             { & $script:ScriptPath -ProjectPath $script:ProjectPath -LinkType 'Telepathy' -InformationAction SilentlyContinue } |
-                Should -Throw '*ValidateSet*'
+                Should-Throw -ExceptionMessage '*ValidateSet*'
         }
     }
 
@@ -52,31 +52,31 @@ Describe 'Install-CopilotStandards' -Tag 'Unit', 'Tools' {
         }
 
         It 'Creates the .github directory' {
-            Join-Path $script:ProjectPath '.github' | Should -Exist
+            Test-Path (Join-Path $script:ProjectPath '.github') | Should-BeTrue
         }
 
         It 'Copies the main Copilot instructions' {
-            Join-Path $script:ProjectPath '.github/copilot-instructions.md' | Should -Exist
+            Test-Path (Join-Path $script:ProjectPath '.github/copilot-instructions.md') | Should-BeTrue
         }
 
         It 'Copies the instructions directory with its content' {
             $dir = Join-Path $script:ProjectPath '.github/instructions'
-            $dir | Should -Exist
-            (Get-ChildItem $dir -Filter '*.instructions.md').Count | Should -BeGreaterThan 0
+            Test-Path $dir | Should-BeTrue
+            (Get-ChildItem $dir -Filter '*.instructions.md').Count | Should-BeGreaterThan 0
         }
 
         It 'Copies the prompts directory with its content' {
             $dir = Join-Path $script:ProjectPath '.github/prompts'
-            $dir | Should -Exist
-            (Get-ChildItem $dir -Filter '*.prompt.md').Count | Should -BeGreaterThan 0
+            Test-Path $dir | Should-BeTrue
+            (Get-ChildItem $dir -Filter '*.prompt.md').Count | Should-BeGreaterThan 0
         }
 
         It 'Creates a .gitignore covering PowerShell and test artifacts' {
             $gitignore = Join-Path $script:ProjectPath '.gitignore'
-            $gitignore | Should -Exist
+            Test-Path $gitignore | Should-BeTrue
             $content = Get-Content $gitignore -Raw
-            $content | Should -Match '\*\.ps1\.bak'
-            $content | Should -Match 'TestResults/'
+            $content | Should-MatchString '\*\.ps1\.bak'
+            $content | Should-MatchString 'TestResults/'
         }
     }
 
@@ -85,28 +85,28 @@ Describe 'Install-CopilotStandards' -Tag 'Unit', 'Tools' {
         It 'Basic creates Tests and Troubleshooting' {
             & $script:ScriptPath -ProjectPath $script:ProjectPath -StandardsType 'Basic' -InformationAction SilentlyContinue
 
-            Join-Path $script:ProjectPath 'Tests' | Should -Exist
-            Join-Path $script:ProjectPath 'Troubleshooting' | Should -Exist
+            Test-Path (Join-Path $script:ProjectPath 'Tests') | Should-BeTrue
+            Test-Path (Join-Path $script:ProjectPath 'Troubleshooting') | Should-BeTrue
         }
 
         It 'Module adds the module layout' {
             & $script:ScriptPath -ProjectPath $script:ProjectPath -StandardsType 'Module' -InformationAction SilentlyContinue
 
             foreach ($folder in 'Public', 'Private', 'Classes', 'Documentation') {
-                Join-Path $script:ProjectPath $folder | Should -Exist
+                Test-Path (Join-Path $script:ProjectPath $folder) | Should-BeTrue
             }
-            Join-Path $script:ProjectPath 'Tests/Unit' | Should -Exist
-            Join-Path $script:ProjectPath 'Tests/Integration' | Should -Exist
+            Test-Path (Join-Path $script:ProjectPath 'Tests/Unit') | Should-BeTrue
+            Test-Path (Join-Path $script:ProjectPath 'Tests/Integration') | Should-BeTrue
         }
 
         It 'Enterprise adds Configuration, Scripts, Tools and a security test folder' {
             & $script:ScriptPath -ProjectPath $script:ProjectPath -StandardsType 'Enterprise' -InformationAction SilentlyContinue
 
             foreach ($folder in 'Configuration', 'Scripts', 'Tools') {
-                Join-Path $script:ProjectPath $folder | Should -Exist
+                Test-Path (Join-Path $script:ProjectPath $folder) | Should-BeTrue
             }
-            Join-Path $script:ProjectPath 'Tests/Security' | Should -Exist
-            Join-Path $script:ProjectPath 'Troubleshooting/Integration' | Should -Exist
+            Test-Path (Join-Path $script:ProjectPath 'Tests/Security') | Should-BeTrue
+            Test-Path (Join-Path $script:ProjectPath 'Troubleshooting/Integration') | Should-BeTrue
         }
     }
 
@@ -118,13 +118,13 @@ Describe 'Install-CopilotStandards' -Tag 'Unit', 'Tools' {
 
             & $script:ScriptPath -ProjectPath $script:ProjectPath -InformationAction SilentlyContinue
 
-            Get-Content $gitignore -Raw | Should -Match 'hand-written, keep me'
+            Get-Content $gitignore -Raw | Should-MatchString 'hand-written, keep me'
         }
 
         It 'Can run twice without error' {
+            # Pester 6 has no Should-NotThrow; a second run that throws fails the test
             & $script:ScriptPath -ProjectPath $script:ProjectPath -StandardsType 'Module' -InformationAction SilentlyContinue
-            { & $script:ScriptPath -ProjectPath $script:ProjectPath -StandardsType 'Module' -InformationAction SilentlyContinue } |
-                Should -Not -Throw
+            & $script:ScriptPath -ProjectPath $script:ProjectPath -StandardsType 'Module' -InformationAction SilentlyContinue
         }
     }
 
@@ -133,9 +133,9 @@ Describe 'Install-CopilotStandards' -Tag 'Unit', 'Tools' {
         It 'Creates nothing when -WhatIf is supplied' {
             & $script:ScriptPath -ProjectPath $script:ProjectPath -StandardsType 'Enterprise' -WhatIf -InformationAction SilentlyContinue
 
-            Join-Path $script:ProjectPath '.github' | Should -Not -Exist
-            Join-Path $script:ProjectPath 'Public' | Should -Not -Exist
-            Join-Path $script:ProjectPath '.gitignore' | Should -Not -Exist
+            Test-Path (Join-Path $script:ProjectPath '.github') | Should-BeFalse
+            Test-Path (Join-Path $script:ProjectPath 'Public') | Should-BeFalse
+            Test-Path (Join-Path $script:ProjectPath '.gitignore') | Should-BeFalse
         }
     }
 
@@ -148,7 +148,7 @@ Describe 'Install-CopilotStandards' -Tag 'Unit', 'Tools' {
             & $script:ScriptPath -ProjectPath $script:ProjectPath -LinkType 'Symlink' `
                 -InformationAction SilentlyContinue -WarningAction SilentlyContinue
 
-            Join-Path $script:ProjectPath '.github/copilot-instructions.md' | Should -Exist
+            Test-Path (Join-Path $script:ProjectPath '.github/copilot-instructions.md') | Should-BeTrue
         }
     }
 
@@ -158,7 +158,7 @@ Describe 'Install-CopilotStandards' -Tag 'Unit', 'Tools' {
             {
                 & $script:ScriptPath -ProjectPath $script:ProjectPath -LinkType 'Submodule' `
                     -InformationAction SilentlyContinue
-            } | Should -Throw '*not a git repository*'
+            } | Should-Throw -ExceptionMessage '*not a git repository*'
         }
 
         It 'Leaves the working directory unchanged after failing' {
@@ -168,7 +168,7 @@ Describe 'Install-CopilotStandards' -Tag 'Unit', 'Tools' {
                     -InformationAction SilentlyContinue -ErrorAction SilentlyContinue
             }
             catch { }
-            (Get-Location).Path | Should -Be $before
+            (Get-Location).Path | Should-Be $before
         }
     }
 
@@ -178,8 +178,8 @@ Describe 'Install-CopilotStandards' -Tag 'Unit', 'Tools' {
             $output = & $script:ScriptPath -ProjectPath $script:ProjectPath -InformationAction Continue 6>&1 |
                 Out-String
 
-            $output | Should -Not -Match 'chat\.promptFiles'
-            $output | Should -Not -Match 'useInstructionFiles'
+            $output | Should-NotMatchString 'chat\.promptFiles'
+            $output | Should-NotMatchString 'useInstructionFiles'
         }
     }
 }

--- a/Tools/Tests/Test-StandardsCompliance.Tests.ps1
+++ b/Tools/Tests/Test-StandardsCompliance.Tests.ps1
@@ -35,12 +35,12 @@ Describe 'Test-StandardsCompliance' -Tag 'Unit', 'Tools' {
 
         It 'Rejects a Path that does not exist' {
             { & $script:ScriptPath -Path (Join-Path $script:FixturePath 'nope') -PassThru -InformationAction SilentlyContinue } |
-                Should -Throw
+                Should-Throw
         }
 
         It 'Rejects an unsupported OutputFormat' {
             { & $script:ScriptPath -Path $script:FixturePath -OutputFormat 'Interpretive-Dance' -PassThru -InformationAction SilentlyContinue } |
-                Should -Throw '*ValidateSet*'
+                Should-Throw -ExceptionMessage '*ValidateSet*'
         }
     }
 
@@ -59,10 +59,10 @@ function Get-Clean {
 '@
             $result = Invoke-Compliance -Path $script:FixturePath
 
-            $result | Should -Not -BeNullOrEmpty
-            $result.TotalFiles | Should -Be 1
-            $result.CorrelationId | Should -Not -BeNullOrEmpty
-            $result.Summary.OverallStatus | Should -BeIn @('PASSED', 'WARNING', 'FAILED')
+            $result | Should-NotBeNull
+            $result.TotalFiles | Should-Be 1
+            $result.CorrelationId | Should-NotBeNull
+            @('PASSED', 'WARNING', 'FAILED') | Should-Any { $_ -eq $result.Summary.OverallStatus }
         }
 
         It 'Counts every PowerShell file it finds' {
@@ -70,13 +70,13 @@ function Get-Clean {
             New-Fixture -Name 'Two.psm1' -Content 'Write-Output 2'
             New-Fixture -Name 'Three.psd1' -Content '@{ ModuleVersion = ''1.0.0'' }'
 
-            (Invoke-Compliance -Path $script:FixturePath).TotalFiles | Should -Be 3
+            (Invoke-Compliance -Path $script:FixturePath).TotalFiles | Should-Be 3
         }
 
         It 'Accepts a single file as the Path' {
             $file = New-Fixture -Name 'Single.ps1' -Content 'Write-Output 1'
 
-            (Invoke-Compliance -Path $file).TotalFiles | Should -Be 1
+            (Invoke-Compliance -Path $file).TotalFiles | Should-Be 1
         }
     }
 
@@ -91,9 +91,8 @@ function Process-Thing {
 '@
             $result = Invoke-Compliance -Path $script:FixturePath
 
-            $result.ComplianceIssues.RuleName | Should -Contain 'UseApprovedVerbs'
-            ($result.ComplianceIssues | Where-Object RuleName -eq 'UseApprovedVerbs').Message |
-                Should -Match 'Process'
+            $result.ComplianceIssues.RuleName | Should-ContainCollection 'UseApprovedVerbs'
+            ($result.ComplianceIssues | Where-Object RuleName -eq 'UseApprovedVerbs').Message | Should-MatchString 'Process'
         }
 
         It 'Does not flag a function using an approved verb' {
@@ -105,7 +104,7 @@ function Get-Thing {
 '@
             $result = Invoke-Compliance -Path $script:FixturePath
 
-            $result.ComplianceIssues.RuleName | Should -Not -Contain 'UseApprovedVerbs'
+            $result.ComplianceIssues.RuleName | Should-NotContainCollection 'UseApprovedVerbs'
         }
     }
 
@@ -120,14 +119,14 @@ Write-Output $config
 '@
             $result = Invoke-Compliance -Path $script:FixturePath
 
-            $result.SecurityIssues | Should -Not -BeNullOrEmpty
-            $result.SecurityIssues.Type | Should -Contain 'HardcodedPassword'
+            $result.SecurityIssues | Should-NotBeNull
+            $result.SecurityIssues.Type | Should-ContainCollection 'HardcodedPassword'
         }
 
         It 'Does not flag a file with no secrets' {
             New-Fixture -Name 'NoSecret.ps1' -Content 'Write-Output "nothing to see"'
 
-            (Invoke-Compliance -Path $script:FixturePath).SecurityIssues | Should -BeNullOrEmpty
+            (Invoke-Compliance -Path $script:FixturePath).SecurityIssues | Should-BeFalsy
         }
     }
 
@@ -144,7 +143,7 @@ Write-Output $items
 '@
             $result = Invoke-Compliance -Path $script:FixturePath
 
-            $result.PerformanceIssues.Type | Should -Contain 'ArrayAppending'
+            $result.PerformanceIssues.Type | Should-ContainCollection 'ArrayAppending'
         }
 
         It 'Flags += when the file targets 5.1' {
@@ -154,8 +153,7 @@ $items = @()
 foreach ($x in 1..10) { $items += $x }
 Write-Output $items
 '@
-            (Invoke-Compliance -Path $script:FixturePath).PerformanceIssues.Type |
-                Should -Contain 'ArrayAppending'
+            (Invoke-Compliance -Path $script:FixturePath).PerformanceIssues.Type | Should-ContainCollection 'ArrayAppending'
         }
 
         It 'Does not flag += when the file targets 7.6' {
@@ -165,8 +163,7 @@ $items = @()
 foreach ($x in 1..10) { $items += $x }
 Write-Output $items
 '@
-            (Invoke-Compliance -Path $script:FixturePath).PerformanceIssues.Type |
-                Should -Not -Contain 'ArrayAppending'
+            (Invoke-Compliance -Path $script:FixturePath).PerformanceIssues.Type | Should-NotContainCollection 'ArrayAppending'
         }
 
         It 'Flags ArrayList on any version' {
@@ -176,8 +173,7 @@ $items = [System.Collections.ArrayList]::new()
 [void]$items.Add(1)
 Write-Output $items
 '@
-            (Invoke-Compliance -Path $script:FixturePath).PerformanceIssues.Type |
-                Should -Contain 'LegacyCollectionType'
+            (Invoke-Compliance -Path $script:FixturePath).PerformanceIssues.Type | Should-ContainCollection 'LegacyCollectionType'
         }
     }
 
@@ -189,9 +185,9 @@ Write-Output $items
 
             Invoke-Compliance -Path $script:FixturePath -Extra @{ OutputFormat = 'JSON'; OutputPath = $out } | Out-Null
 
-            $out | Should -Exist
-            { Get-Content $out -Raw | ConvertFrom-Json } | Should -Not -Throw
-            (Get-Content $out -Raw | ConvertFrom-Json).TotalFiles | Should -Be 1
+            Test-Path $out | Should-BeTrue
+            $null = Get-Content $out -Raw | ConvertFrom-Json   # invalid JSON throws, failing the test
+            (Get-Content $out -Raw | ConvertFrom-Json).TotalFiles | Should-Be 1
         }
     }
 
@@ -200,13 +196,13 @@ Write-Output $items
         It 'Handles a directory with no PowerShell files' {
             $result = Invoke-Compliance -Path $script:FixturePath
 
-            $result.TotalFiles | Should -Be 0
+            $result.TotalFiles | Should-Be 0
         }
 
         It 'Emits exactly one results object, not one per code path' {
             New-Fixture -Name 'Sample.ps1' -Content 'Write-Output 1'
 
-            @(Invoke-Compliance -Path $script:FixturePath).Count | Should -Be 1
+            @(Invoke-Compliance -Path $script:FixturePath).Count | Should-Be 1
         }
     }
 
@@ -222,18 +218,18 @@ function Get-Clean {
 '@
             $result = Invoke-Compliance -Path $script:FixturePath
 
-            $result.Summary.OverallStatus | Should -Be 'PASSED'
-            $result.PassedFiles | Should -Be 1
-            $result.FailedFiles | Should -Be 0
+            $result.Summary.OverallStatus | Should-Be 'PASSED'
+            $result.PassedFiles | Should-Be 1
+            $result.FailedFiles | Should-Be 0
         }
 
         It 'Reports a run with a non-approved verb as FAILED' {
             New-Fixture -Name 'BadVerb.ps1' -Content 'function Process-Thing { Write-Output 1 }'
             $result = Invoke-Compliance -Path $script:FixturePath
 
-            $result.Summary.OverallStatus | Should -Be 'FAILED'
-            $result.FailedFiles | Should -Be 1
-            $result.Summary.CompliancePercentage | Should -Be 0
+            $result.Summary.OverallStatus | Should-Be 'FAILED'
+            $result.FailedFiles | Should-Be 1
+            $result.Summary.CompliancePercentage | Should-Be 0
         }
 
         It 'Totals analysis time across files as a TimeSpan' {
@@ -241,8 +237,8 @@ function Get-Clean {
             New-Fixture -Name 'B.ps1' -Content 'Write-Output 2'
             $result = Invoke-Compliance -Path $script:FixturePath
 
-            $result.Summary.TotalAnalysisTime | Should -BeOfType [TimeSpan]
-            $result.Summary.TotalAnalysisTime.Ticks | Should -BeGreaterThan 0
+            $result.Summary.TotalAnalysisTime | Should-HaveType ([TimeSpan])
+            $result.Summary.TotalAnalysisTime.Ticks | Should-BeGreaterThan 0
         }
 
         It 'Produces per-file results with distinct issue sets' {
@@ -254,8 +250,8 @@ function Get-Clean {
             # so issues leaked between files.
             $bad = $result.FileResults | Where-Object FileName -eq 'BadVerb.ps1'
             $clean = $result.FileResults | Where-Object FileName -eq 'Clean.ps1'
-            $bad.Issues.Count | Should -BeGreaterThan 0
-            $clean.Issues.Count | Should -Be 0
+            $bad.Issues.Count | Should-BeGreaterThan 0
+            $clean.Issues.Count | Should-Be 0
         }
 
         It 'Writes detailed output when -Detailed is supplied' {
@@ -264,7 +260,7 @@ function Get-Clean {
             $output = & $script:ScriptPath -Path $script:FixturePath -PassThru -Detailed `
                 -InformationAction Continue 6>&1 | Out-String
 
-            $output | Should -Match 'BadVerb\.ps1'
+            $output | Should-MatchString 'BadVerb\.ps1'
         }
 
         It 'Skips test files when -ExcludeTests is supplied' {
@@ -274,8 +270,8 @@ function Get-Clean {
             $withTests = Invoke-Compliance -Path $script:FixturePath
             $withoutTests = Invoke-Compliance -Path $script:FixturePath -Extra @{ ExcludeTests = $true }
 
-            $withTests.TotalFiles | Should -Be 2
-            $withoutTests.TotalFiles | Should -BeLessThan $withTests.TotalFiles
+            $withTests.TotalFiles | Should-Be 2
+            $withoutTests.TotalFiles | Should-BeLessThan $withTests.TotalFiles
         }
     }
 
@@ -287,8 +283,8 @@ function Get-Clean {
 
             Invoke-Compliance -Path $script:FixturePath -Extra @{ OutputFormat = 'XML'; OutputPath = $out } | Out-Null
 
-            $out | Should -Exist
-            (Get-Item $out).Length | Should -BeGreaterThan 0
+            Test-Path $out | Should-BeTrue
+            (Get-Item $out).Length | Should-BeGreaterThan 0
         }
 
         It 'Writes an HTML report' {
@@ -297,8 +293,8 @@ function Get-Clean {
 
             Invoke-Compliance -Path $script:FixturePath -Extra @{ OutputFormat = 'HTML'; OutputPath = $out } | Out-Null
 
-            $out | Should -Exist
-            Get-Content $out -Raw | Should -Match '<html'
+            Test-Path $out | Should-BeTrue
+            Get-Content $out -Raw | Should-MatchString '<html'
         }
     }
 }


### PR DESCRIPTION
Migrates the test suite from classic `Should -Be` to the Pester 6 `Should-*` family.

## Why

The example tests used classic assertions while the repository teaches `Should-*`, so the examples
demonstrated the older style. `assertion-guide.md` permits classic assertions in existing suites and
prefers `Should-*` for new files.

All four test files are migrated. The `Tools/Tests/` files are included because they were added in
#13 as new files and should have used `Should-*` from the start; leaving them classic would have
split the repository across two conventions.

## Cases with no direct equivalent

Handled as `assertion-guide.md` prescribes:

| Classic | Replacement | Reason |
|---|---|---|
| `Should -Not -Throw` | Call stands alone | No `Should-NotThrow` exists; an unhandled exception fails the test |
| `Should -Exist` | `Test-Path <path> \| Should-BeTrue` | No `Should-*` form. Rewritten rather than leaving classic assertions mixed into migrated files |
| `Should -BeIn @(...)` | `Should-Any { $_ -eq $x }` | No 1:1 form |
| `Should -Not -BeIn @(...)` | `Should-All { $_ -ne $x }` | As above |
| `Should -Not -BeNullOrEmpty` | `Should-NotBeNull`, `Should-NotBeEmptyString`, or `Should-BeFalsy` | Conflated three questions; each site now states which it means |

`Should-Throw -ExceptionMessage` matches with wildcards, so substring matches keep their leading and
trailing asterisks. This differs from classic `Should -Throw`, where the wildcards were nearly always
required for the same effect.

## Two conversions that were wrong

Both produced syntactically valid but incorrect code, and were caught by running the suite rather
than by review:

```powershell
# Missing parentheses - Test-Path received Join-Path as a positional argument
Test-Path Join-Path $script:ProjectPath '.github' | Should-BeTrue

# Should-HaveType takes a type object, so the literal needs parentheses
$result.Summary.TotalAnalysisTime | Should-HaveType [TimeSpan]
```

Eight tests failed on the first run after conversion. Both are fixed.

## Verification

A migrated assertion that still passes may be passing for the wrong reason, so the replacements were
checked against negative cases:

| Assertion | Fails when it should |
|---|---|
| `Should-ContainCollection` on an absent item | yes |
| `Should-NotContainCollection` on a present item | yes |
| `Should-Any` with no match | yes |
| `Should-All` with one violating item | yes |
| `Should-BeFalse` on `$true` | yes |

Suite result: **78/78 passing**, 0 analyzer errors or warnings in production files, coverage 88.59%.

No classic assertions remain. Two matches for `Should -` survive in
`Test-QualityGates.Tests.ps1`, both inside comments explaining how the classic form differed.
