### PR TITLE
fix: make Test-StandardsCompliance actually enforce the standards

### DIFF
--- a/Tools/Test-StandardsCompliance.ps1
+++ b/Tools/Test-StandardsCompliance.ps1
@@ -23,6 +23,11 @@
 .PARAMETER OutputPath
     Path to save detailed results (when using JSON, XML, or HTML format)
 
+.PARAMETER PassThru
+    Return the results object instead of exiting with a status code. Without it the
+    script exits 1 when any issue is found and 0 otherwise, which suits CI but
+    prevents a caller from reading the results.
+
 .EXAMPLE
     .\Test-StandardsCompliance.ps1 -Path "." -Detailed
     
@@ -114,7 +119,15 @@ begin {
         SecurityIssues = @()
         PerformanceIssues = @()
         ComplianceIssues = @()
-        Summary = @{}
+        # Populated with defaults so an early return - no files found - still yields
+        # a coherent object. Previously the summary stayed empty and the console
+        # printed "Compliance: %".
+        Summary = @{
+            CompliancePercentage = 0
+            OverallStatus        = 'NOT-RUN'
+            TotalAnalysisTime    = [TimeSpan]::Zero
+            AverageFileSize      = 0
+        }
     }
 }
 
@@ -133,10 +146,13 @@ process {
         
         # Exclude test files if requested
         if ($ExcludeTests) {
-            $psFiles = $psFiles | Where-Object { 
-                $_.FullName -notlike "*test*" -and 
-                $_.FullName -notlike "*Test*" -and
-                $_.Name -notlike "*.Tests.ps1"
+            # Match the file name and the Tests directory, never the whole path.
+            # Testing $_.FullName meant a project living under any path containing
+            # "test" - C:\testing\MyProject - excluded every file and analysed
+            # nothing, while still reporting success.
+            $psFiles = $psFiles | Where-Object {
+                $_.Name -notlike "*.Tests.ps1" -and
+                $_.FullName -notlike "*$([IO.Path]::DirectorySeparatorChar)Tests$([IO.Path]::DirectorySeparatorChar)*"
             }
         }
         
@@ -198,19 +214,48 @@ process {
                     # Community standards check
                     $content = Get-Content $file.FullName -Raw -ErrorAction SilentlyContinue
                     if ($content) {
+
+                        # Anti-pattern rules run against code with comments and string
+                        # literals blanked out. Matching raw text flagged every file
+                        # that *documents* an anti-pattern - including this script,
+                        # whose rule table names the patterns it looks for, and the
+                        # examples whose comments explain what not to do.
+                        $codeOnly = $content
+                        $tokens = $null
+                        $null = [System.Management.Automation.Language.Parser]::ParseInput(
+                            $content, [ref]$tokens, [ref]$null)
+                        if ($tokens) {
+                            $sb = [System.Text.StringBuilder]::new($content)
+                            foreach ($tok in ($tokens | Where-Object {
+                                    $_.Kind -eq 'Comment' -or $_.Kind -eq 'StringLiteral' -or $_.Kind -eq 'StringExpandable'
+                                })) {
+                                $start = $tok.Extent.StartOffset
+                                $len = $tok.Extent.EndOffset - $start
+                                if ($len -gt 0 -and ($start + $len) -le $sb.Length) {
+                                    $replacement = (($tok.Extent.Text -replace '[^\r\n]', ' '))
+                                    $null = $sb.Remove($start, $len).Insert($start, $replacement)
+                                }
+                            }
+                            $codeOnly = $sb.ToString()
+                        }
                         
-                        # Check for approved verbs
-                        if ($content -match 'function\s+([^-\s]+)-') {
-                            $verb = $Matches[1]
-                            $approvedVerbs = Get-Verb | Select-Object -ExpandProperty Verb
+                        # Check for approved verbs on EVERY function.
+                        # -match returns only the first match in a multi-line string,
+                        # so the previous form inspected the first function and
+                        # ignored the rest: a file whose first function used an
+                        # approved verb passed however many later ones did not.
+                        $approvedVerbs = Get-Verb | Select-Object -ExpandProperty Verb
+                        foreach ($m in [regex]::Matches($codeOnly, '(?im)^\s*function\s+([^-\s]+)-(\S+)')) {
+                            $verb = $m.Groups[1].Value
                             if ($verb -notin $approvedVerbs) {
+                                $line = ($content.Substring(0, $m.Index) -split "`n").Count
                                 $complianceIssue = [PSCustomObject]@{
                                     RuleName = 'UseApprovedVerbs'
                                     Severity = 'Error'
                                     ScriptName = $file.Name
-                                    Line = 0
+                                    Line = $line
                                     Column = 0
-                                    Message = "Function uses non-approved verb: $verb"
+                                    Message = "Function uses non-approved verb: $verb ($verb-$($m.Groups[2].Value))"
                                     ScriptPath = $file.FullName
                                 }
                                 $fileResult.Issues += $complianceIssue
@@ -218,6 +263,82 @@ process {
                                 $results.CriticalIssues++
                                 $fileResult.Passed = $false
                             }
+                        }
+
+                        # Anti-patterns copilot-instructions.md names explicitly but
+                        # nothing enforced. Each maps to a line in "Anti-Patterns to
+                        # Avoid" or "Modern PowerShell Features".
+                        $antiPatterns = @{
+                            'UseDollarUnderscoreInCatch' = @{
+                                Pattern  = '(?s)catch\s*\{[^}]*\$Error\[0\]'
+                                Message  = 'Uses $Error[0] in a catch block; use $_ instead'
+                                Severity = 'Error'
+                            }
+                            'AvoidPSCustomObjectOutputType' = @{
+                                Pattern  = '\[OutputType\(\[PSCustomObject\]\)\]'
+                                Message  = 'Misleading [OutputType([PSCustomObject])]; name the type instead'
+                                Severity = 'Error'
+                            }
+                            'UseModernCredentialCreation' = @{
+                                Pattern  = 'New-Object\s+(-TypeName\s+)?(System\.Management\.Automation\.)?PSCredential'
+                                Message  = 'Uses New-Object for a credential; use [PSCredential]::new()'
+                                Severity = 'Warning'
+                            }
+                        }
+
+                        foreach ($rule in $antiPatterns.GetEnumerator()) {
+                            if ($codeOnly -match $rule.Value.Pattern) {
+                                $complianceIssue = [PSCustomObject]@{
+                                    RuleName   = $rule.Key
+                                    Severity   = $rule.Value.Severity
+                                    ScriptName = $file.Name
+                                    Line       = 0
+                                    Column     = 0
+                                    Message    = $rule.Value.Message
+                                    ScriptPath = $file.FullName
+                                }
+                                $fileResult.Issues += $complianceIssue
+                                $results.ComplianceIssues += $complianceIssue
+                                if ($rule.Value.Severity -eq 'Error') { $results.CriticalIssues++ } else { $results.HighIssues++ }
+                                $fileResult.Passed = $false
+                            }
+                        }
+
+                        # #requires is itself a comment, so this runs against raw
+                        # content rather than $codeOnly.
+                        if ($content -match '(?im)^\s*#requires\s+-Version\s+(6\.\d+|7\.[0-3])\b') {
+                            $complianceIssue = [PSCustomObject]@{
+                                RuleName   = 'AvoidRetiredVersionRequires'
+                                Severity   = 'Warning'
+                                ScriptName = $file.Name
+                                Line       = 0
+                                Column     = 0
+                                Message    = 'Targets a retired PowerShell version; 7.4 is the lowest supported floor'
+                                ScriptPath = $file.FullName
+                            }
+                            $fileResult.Issues += $complianceIssue
+                            $results.ComplianceIssues += $complianceIssue
+                            $results.HighIssues++
+                            $fileResult.Passed = $false
+                        }
+
+                        # Comment-based help that opens with # instead of <# is
+                        # silently ignored by Get-Help, so the function ships with no
+                        # discoverable help at all.
+                        if ($content -match '(?m)^\s*#\s*\.(SYNOPSIS|DESCRIPTION)\b') {
+                            $complianceIssue = [PSCustomObject]@{
+                                RuleName   = 'UseBlockCommentBasedHelp'
+                                Severity   = 'Error'
+                                ScriptName = $file.Name
+                                Line       = 0
+                                Column     = 0
+                                Message    = 'Comment-based help uses # rather than a <# ... #> block; Get-Help will not see it'
+                                ScriptPath = $file.FullName
+                            }
+                            $fileResult.Issues += $complianceIssue
+                            $results.ComplianceIssues += $complianceIssue
+                            $results.CriticalIssues++
+                            $fileResult.Passed = $false
                         }
                         
                         # Security checks
@@ -452,8 +573,14 @@ end {
         Write-Information "    /code-analysis for comprehensive analysis" -InformationAction Continue
         Write-Information "    /validate-standards for community standards compliance" -InformationAction Continue
     }
+    elseif ($results.TotalFiles -eq 0) {
+        # Analysing nothing is not compliance. Previously this printed the success
+        # message and exited 0, so a misconfigured path or an over-broad
+        # -ExcludeTests filter looked like a clean pass.
+        Write-Warning "No PowerShell files were analysed - nothing has been verified. Check -Path and -ExcludeTests."
+    }
     else {
-        Write-Information "`nAll files meet PowerShell enterprise standards!" -InformationAction Continue
+        Write-Information "`nAll $($results.TotalFiles) file(s) meet PowerShell enterprise standards!" -InformationAction Continue
     }
 
     Write-Verbose "Analysis completed in $([math]::Round($results.Summary.TotalAnalysisTime.TotalSeconds, 2)) seconds"

--- a/Tools/Tests/Test-StandardsCompliance.Tests.ps1
+++ b/Tools/Tests/Test-StandardsCompliance.Tests.ps1
@@ -108,6 +108,145 @@ function Get-Thing {
         }
     }
 
+    Context 'Approved verb detection' {
+
+        It 'Flags a non-approved verb that is not the first function in the file' {
+            # -match returns only the first match in a multi-line string, so the
+            # previous implementation inspected function one and ignored the rest.
+            New-Fixture -Name 'SecondBad.ps1' -Content @'
+function Get-Good {
+    param([Parameter(Mandatory)][string]$Name)
+    Write-Output $Name
+}
+
+function Process-Bad {
+    param([Parameter(Mandatory)][string]$Name)
+    Write-Output $Name
+}
+'@
+            $result = Invoke-Compliance -Path $script:FixturePath
+
+            $result.ComplianceIssues.RuleName | Should-ContainCollection 'UseApprovedVerbs'
+            ($result.ComplianceIssues | Where-Object RuleName -eq 'UseApprovedVerbs').Message |
+                Should-MatchString 'Process'
+        }
+
+        It 'Flags every offending function, not just one' {
+            New-Fixture -Name 'TwoBad.ps1' -Content @'
+function Process-One { param([Parameter(Mandatory)][string]$A) $A }
+function Handle-Two { param([Parameter(Mandatory)][string]$A) $A }
+'@
+            $verbIssues = (Invoke-Compliance -Path $script:FixturePath).ComplianceIssues |
+                Where-Object RuleName -eq 'UseApprovedVerbs'
+
+            $verbIssues | Should-BeCollection -Count 2
+        }
+
+        It 'Ignores a function name that only appears in a comment' {
+            New-Fixture -Name 'CommentedVerb.ps1' -Content @'
+# Do not write: function Process-Thing { }
+function Get-Thing {
+    param([Parameter(Mandatory)][string]$Name)
+    Write-Output $Name
+}
+'@
+            (Invoke-Compliance -Path $script:FixturePath).ComplianceIssues.RuleName |
+                Should-NotContainCollection 'UseApprovedVerbs'
+        }
+    }
+
+    Context 'Documented anti-patterns' {
+
+        It 'Flags $Error[0] used in a catch block' {
+            New-Fixture -Name 'ErrorZero.ps1' -Content @'
+function Get-Thing {
+    param([Parameter(Mandatory)][string]$Name)
+    try { Get-Item $Name } catch { Write-Error $Error[0].Exception.Message }
+}
+'@
+            (Invoke-Compliance -Path $script:FixturePath).ComplianceIssues.RuleName |
+                Should-ContainCollection 'UseDollarUnderscoreInCatch'
+        }
+
+        It 'Flags a misleading PSCustomObject output type' {
+            New-Fixture -Name 'BadOutputType.ps1' -Content @'
+function Get-Thing {
+    [OutputType([PSCustomObject])]
+    param([Parameter(Mandatory)][string]$Name)
+    [PSCustomObject]@{ Name = $Name }
+}
+'@
+            (Invoke-Compliance -Path $script:FixturePath).ComplianceIssues.RuleName |
+                Should-ContainCollection 'AvoidPSCustomObjectOutputType'
+        }
+
+        It 'Flags New-Object credential creation' {
+            New-Fixture -Name 'OldCred.ps1' -Content @'
+function Get-Thing {
+    param([Parameter(Mandatory)][string]$User, [Parameter(Mandatory)][securestring]$Pass)
+    New-Object PSCredential $User, $Pass
+}
+'@
+            (Invoke-Compliance -Path $script:FixturePath).ComplianceIssues.RuleName |
+                Should-ContainCollection 'UseModernCredentialCreation'
+        }
+
+        It 'Flags a requires directive targeting a retired version' {
+            New-Fixture -Name 'Retired.ps1' -Content @'
+#requires -Version 7.0
+function Get-Thing { param([Parameter(Mandatory)][string]$A) $A }
+'@
+            (Invoke-Compliance -Path $script:FixturePath).ComplianceIssues.RuleName |
+                Should-ContainCollection 'AvoidRetiredVersionRequires'
+        }
+
+        It 'Does not flag a requires directive targeting a supported version' {
+            New-Fixture -Name 'Supported.ps1' -Content @'
+#requires -Version 7.6
+function Get-Thing { param([Parameter(Mandatory)][string]$A) $A }
+'@
+            (Invoke-Compliance -Path $script:FixturePath).ComplianceIssues.RuleName |
+                Should-NotContainCollection 'AvoidRetiredVersionRequires'
+        }
+
+        It 'Flags comment-based help that Get-Help cannot see' {
+            New-Fixture -Name 'BrokenHelp.ps1' -Content @'
+# .SYNOPSIS
+#     This never reaches Get-Help - it needs a <# ... #> block
+function Get-Thing {
+    param([Parameter(Mandatory)][string]$A)
+    $A
+}
+'@
+            (Invoke-Compliance -Path $script:FixturePath).ComplianceIssues.RuleName |
+                Should-ContainCollection 'UseBlockCommentBasedHelp'
+        }
+    }
+
+    Context 'Anti-pattern rules ignore comments and strings' {
+
+        It 'Does not flag a file that merely documents an anti-pattern' {
+            # Every rule below appears here only inside a comment or a string. A
+            # naive text match flagged the repository's own examples and this very
+            # script, whose rule table names the patterns it searches for.
+            New-Fixture -Name 'DocumentsThem.ps1' -Content @'
+function Get-Thing {
+    <#
+        .SYNOPSIS
+            Documents what not to do.
+        .DESCRIPTION
+            Avoid [OutputType([PSCustomObject])]. Use $_ in catch, never $Error[0].
+            Prefer [PSCredential]::new() over New-Object PSCredential.
+    #>
+    param([Parameter(Mandatory)][string]$Name)
+    $guidance = 'do not use $Error[0] in a catch block'
+    Write-Output "$Name $guidance"
+}
+'@
+            (Invoke-Compliance -Path $script:FixturePath).ComplianceIssues | Should-BeFalsy
+        }
+    }
+
     Context 'Security detection' {
 
         It 'Flags a hardcoded password' {
@@ -199,6 +338,24 @@ Write-Output $items
             $result.TotalFiles | Should-Be 0
         }
 
+        It 'Does not claim success when nothing was analysed' {
+            # Analysing zero files is not compliance. It previously printed
+            # "All files meet PowerShell enterprise standards!" and exited 0.
+            & $script:ScriptPath -Path $script:FixturePath -PassThru `
+                -InformationAction SilentlyContinue -WarningVariable warned | Out-Null
+
+            "$warned" | Should-MatchString 'nothing has been verified'
+        }
+
+        It 'Reports a coherent summary when nothing was analysed' {
+            $result = & $script:ScriptPath -Path $script:FixturePath -PassThru `
+                -InformationAction SilentlyContinue -WarningAction SilentlyContinue
+
+            # Previously the summary stayed empty and the console printed "Compliance: %"
+            $result.Summary.CompliancePercentage | Should-Be 0
+            $result.Summary.OverallStatus | Should-Be 'NOT-RUN'
+        }
+
         It 'Emits exactly one results object, not one per code path' {
             New-Fixture -Name 'Sample.ps1' -Content 'Write-Output 1'
 
@@ -261,6 +418,25 @@ function Get-Clean {
                 -InformationAction Continue 6>&1 | Out-String
 
             $output | Should-MatchString 'BadVerb\.ps1'
+        }
+
+        It 'Does not exclude everything when the project path contains "test"' {
+            # Regression: the filter tested $_.FullName, so a project under
+            # C:\testing\... excluded every file and still reported success.
+            $pathWithTest = Join-Path ([System.IO.Path]::GetTempPath()) "testing-$([guid]::NewGuid().ToString('N'))"
+            New-Item -Path $pathWithTest -ItemType Directory -Force | Out-Null
+            try {
+                Set-Content (Join-Path $pathWithTest 'Get-Real.ps1') 'function Get-Real { param([Parameter(Mandatory)][string]$N) $N }'
+                Set-Content (Join-Path $pathWithTest 'Thing.Tests.ps1') 'Describe "x" { It "y" { $true } }'
+
+                $result = & $script:ScriptPath -Path $pathWithTest -ExcludeTests -PassThru `
+                    -InformationAction SilentlyContinue -WarningAction SilentlyContinue
+
+                $result.TotalFiles | Should-Be 1
+            }
+            finally {
+                Remove-Item $pathWithTest -Recurse -Force -ErrorAction SilentlyContinue
+            }
         }
 
         It 'Skips test files when -ExcludeTests is supplied' {


### PR DESCRIPTION
Verification of the two `Tools/` scripts against what they claim to do.

`Install-CopilotStandards.ps1` checked out accurate — it copies all 25 instruction files and 10
prompts, and the Basic, Module and Enterprise structures match the documentation. Verified by running
it and diffing the result against source.

`Test-StandardsCompliance.ps1` did not.

## The verb check only inspected the first function

```powershell
if ($content -match 'function\s+([^-\s]+)-') { ... }
```

`-match` returns only the **first** match in a multi-line string, so a file whose first function used
an approved verb passed regardless of the rest. Running the checker against the repository's own
anti-pattern file reported **zero** verb violations while `Process-TestData` sat in plain sight —
PSScriptAnalyzer caught it, the tool's own rule did not.

Now iterates every function with `[regex]::Matches` and reports each with a line number.

## `-ExcludeTests` could exclude everything

It filtered on `$_.FullName` against `*test*`, so a project under any path containing "test" —
`C:\testing\MyProject` — excluded every file:

```
project path contains 'test'
  files without -ExcludeTests : 2
  files with    -ExcludeTests : 0   <- analysed nothing
```

Now matches the file name and a `Tests` directory, mirroring the workflow fix in #17.

## Analysing nothing reported success

Combined with the above, zero files printed **"All files meet PowerShell enterprise standards!"** and
exited 0 — a green pass having verified nothing. It now warns explicitly.

The summary also stayed empty on that path, because the early `return` skipped its computation, so
the console printed `Compliance: %`. It is initialised with defaults and reports `OverallStatus`
`NOT-RUN`.

## It enforced a small subset of the standards it claims to validate

Four anti-patterns `copilot-instructions.md` names explicitly had **no rule at all**:

| Rule added | The standard it enforces |
|---|---|
| `UseDollarUnderscoreInCatch` | "Don't use `$Error[0]` in catch blocks (use `$_`)" |
| `AvoidPSCustomObjectOutputType` | "Don't use misleading `[OutputType([PSCustomObject])]` declarations" |
| `UseBlockCommentBasedHelp` | "Don't use broken comment-based help (missing `<#` opener)" |
| `UseModernCredentialCreation` | "Use `[PSCredential]::new()` instead of `New-Object`" |
| `AvoidRetiredVersionRequires` | 7.4 is the lowest supported floor |

## Adding them reproduced the #11 defect

Matching raw text flagged every file that **documents** an anti-pattern — including this script,
whose rule table names the patterns it searches for, and `Basic-Function-Example.ps1`, whose comment
explains why not to use `[OutputType([PSCustomObject])]`. That file was fixed in #17; the checker
flagged it for the comment describing the fix.

Anti-pattern rules now run against source with comment and string tokens blanked out by the
PowerShell parser. The rules that legitimately inspect comments — `#requires` and the broken
comment-based-help check — still read raw content.

## `-PassThru` was undocumented

Added in #13, never given a `.PARAMETER` entry.

## Verification

Both directions, since a rule that only fires is as useless as one that never does:

| Target | Result |
|---|---|
| `Tools/` | clean |
| `Templates/` | clean |
| `Documentation/Examples/Module-Structure-Example` | clean |
| `Basic-Function-Example.ps1` | clean |
| `Test-QualityGates.ps1` | **3 rules fire** — `UseApprovedVerbs`, `AvoidPSCustomObjectOutputType`, `UseDollarUnderscoreInCatch` |

The anti-pattern file went from 0 critical issues and `WARNING` to 3 and `FAILED`.

**124 tests, 0 analyzer errors or warnings, coverage 93.23%** (Tools alone 93.72%, up from 92.31%).
