### PR TITLE
docs: reference the examples from the instructions that describe them

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -679,12 +679,27 @@ For specialized scenarios, reference these instruction files:
 - **Community Standards**: [Best Practices Integration](./instructions/community-standards.instructions.md)
 - **Style Enforcement**: [Style Guide Compliance](./instructions/style-enforcement.instructions.md)
 
+### Worked Examples
+
+Prefer matching these over inventing a shape. Each is complete, runs, and passes the quality gates
+described above:
+
+| Need | Example |
+|---|---|
+| A complete advanced function | [Basic-Function-Example.ps1](../Documentation/Examples/Basic-Function-Example.ps1) |
+| Module layout and export boundary | [Module-Structure-Example](../Documentation/Examples/Module-Structure-Example/) |
+| Pester 6 tests, including private functions | [Module-Structure-Example/Tests](../Documentation/Examples/Module-Structure-Example/Tests/) |
+| Mocking CIM and typed parameters | [Testing-Examples](../Documentation/Examples/Testing-Examples/) |
+| A module template to copy | [Templates/Powershell-Module](../Templates/Powershell-Module/) |
+
+[Test-QualityGates.ps1](../Documentation/Examples/Test-QualityGates.ps1) is the exception: it
+intentionally violates these standards so the gates have something to catch. Never use it as a model.
+
 ### Implementation Documentation
 
 - [Implementation Guide](../Documentation/Implementation-Guide.md): Step-by-step setup and adoption
 - [PowerShell Best Practices](../Documentation/PowerShell-Best-Practices.md): Comprehensive community standards
 - [Enterprise Extensions](../Documentation/Enterprise-Extensions.md): Organizational customizations
-- [Examples](../Documentation/Examples/): Working code demonstrating these standards
 - [Troubleshooting Guides](../Troubleshooting/): Organized problem-solving resources
 
 ---

--- a/.github/instructions/cicd.instructions.md
+++ b/.github/instructions/cicd.instructions.md
@@ -92,6 +92,23 @@ if ($analysisResults) {
 }
 ```
 
+`-Settings` takes any of the presets PSScriptAnalyzer ships, so the formatting rules in
+[style-enforcement.instructions.md](./style-enforcement.instructions.md) do not need a hand-written
+settings file. `CodeFormattingOTBS` already configures them:
+
+```powershell
+# One True Brace Style, 4-space indentation, operator and separator spacing,
+# assignment alignment, and cmdlet casing - all built in
+Invoke-ScriptAnalyzer -Path . -Recurse -Settings CodeFormattingOTBS
+```
+
+Run both when a team wants correctness and formatting checked together. The one documented rule no
+preset covers is the 115-character line limit; add `PSAvoidLongLines` explicitly if it matters to
+the team.
+
+Which presets to adopt is the consuming team's decision - these standards describe the practices,
+not the audit configuration.
+
 #### Testing and Coverage
 
 ```powershell

--- a/.github/instructions/comments.instructions.md
+++ b/.github/instructions/comments.instructions.md
@@ -12,6 +12,12 @@ documentation and business communication. Create help that supports automatic RE
 
 ## Help Generation Requirements
 
+> **Worked example**:
+> [Basic-Function-Example.ps1](../../Documentation/Examples/Basic-Function-Example.ps1) carries a
+> complete help block in the form described here - synopsis, description, per-parameter text,
+> multiple examples with expected output, and `.NOTES` with troubleshooting links but no change
+> history.
+
 ### Mandatory Sections
 
 Generate complete comment-based help including all required sections:

--- a/.github/instructions/errorsandlogs.instructions.md
+++ b/.github/instructions/errorsandlogs.instructions.md
@@ -10,6 +10,13 @@ description: 'Implements comprehensive error handling and structured logging for
 Implement robust error handling and structured logging patterns for PowerShell code that ensure proper error management,
 correlation tracking, and enterprise-grade diagnostic capabilities.
 
+> **Worked examples**:
+> [Basic-Function-Example.ps1](../../Documentation/Examples/Basic-Function-Example.ps1) and
+> [Get-ExampleData.ps1](../../Documentation/Examples/Module-Structure-Example/Public/Get-ExampleData.ps1)
+> both generate a correlation ID once in `begin`, carry it through every message, use `$_` in the
+> catch, and `continue` so one failed item does not abort the batch. Both failure paths are covered
+> by tests.
+
 ## Error Handling Implementation
 
 ### Comprehensive Error Handling Pattern

--- a/.github/instructions/module.instructions.md
+++ b/.github/instructions/module.instructions.md
@@ -36,6 +36,13 @@ Collect essential information for module development:
 
 ## Module Structure Generation
 
+> **Worked example**:
+> [Documentation/Examples/Module-Structure-Example](../../Documentation/Examples/Module-Structure-Example/)
+> is a small working module implementing everything in this section - the folder layout, the load
+> order in `ModuleExample.psm1`, an explicit `FunctionsToExport`, a class used as a named output
+> type, and a private helper that is never exported. Read it before generating a new module; prefer
+> matching its shape over inventing one.
+
 ### Standard Module Directory Structure
 
 Create the complete module structure following enterprise standards:
@@ -74,7 +81,10 @@ ModuleName/
 
 ### Module Manifest Creation
 
-Generate comprehensive module manifest (ModuleName.psd1):
+Generate comprehensive module manifest (ModuleName.psd1). For a complete, valid manifest see
+[ModuleExample.psd1](../../Documentation/Examples/Module-Structure-Example/ModuleExample.psd1) -
+note that `FunctionsToExport` names each public function explicitly, which is what keeps private
+helpers internal:
 
 ```powershell
 @{
@@ -123,10 +133,15 @@ Generate comprehensive module manifest (ModuleName.psd1):
 
 ### Root Module Implementation
 
-Create optimized root module file (ModuleName.psm1):
+Create optimized root module file (ModuleName.psm1). Load order matters: classes first, then private
+functions, then public ones - see
+[ModuleExample.psm1](../../Documentation/Examples/Module-Structure-Example/ModuleExample.psm1) for a
+working loader.
 
 ```powershell
-#Requires -Version 5.1
+# Match the manifest's PowerShellVersion. This template targets 7.6; use 5.1 only
+# when the module is built for Windows PowerShell compatibility.
+#Requires -Version 7.6
 
 # Module initialization
 $ModuleRoot = $PSScriptRoot

--- a/.github/instructions/pester-supporting-docs/mocking-patterns.md
+++ b/.github/instructions/pester-supporting-docs/mocking-patterns.md
@@ -54,6 +54,25 @@ You no longer need `Write-Host` debugging to work out why a parameter filter did
 Aliases are matched in `-ParameterFilter`, and mocking falls back gracefully when a command cannot
 produce dynamic parameters.
 
+### Mocking inside a module
+
+A mock declared in a test file replaces the command for callers in that file. To replace a function
+that a _module's_ code calls - typically a private helper - declare the mock inside
+`InModuleScope`, where the module's internal scope is visible:
+
+```powershell
+InModuleScope MyModule {
+    Mock Get-ServiceStatus { throw 'service unreachable' }
+
+    # Get-Data is public; Get-ServiceStatus is private and never exported
+    'Billing', 'Identity' | Get-Data -ErrorAction SilentlyContinue
+}
+```
+
+Worked instance:
+[Module-Structure-Example/Tests](../../../Documentation/Examples/Module-Structure-Example/Tests/)
+mocks a private function this way to exercise a per-item failure path.
+
 ## Advanced Mocking Strategies
 
 ### Context-Aware Mocking

--- a/.github/instructions/pester-supporting-docs/unit-test-template.md
+++ b/.github/instructions/pester-supporting-docs/unit-test-template.md
@@ -8,6 +8,11 @@ text descriptions and standard ASCII characters only.
 
 ## Standard Unit Test Structure
 
+> Complete passing implementations of this template:
+> [Module-Structure-Example/Tests](../../../Documentation/Examples/Module-Structure-Example/Tests/)
+> and
+> [Testing-Examples](../../../Documentation/Examples/Testing-Examples/).
+
 Use this template for all unit tests:
 
 ```powershell

--- a/.github/instructions/pester.instructions.md
+++ b/.github/instructions/pester.instructions.md
@@ -137,6 +137,47 @@ tags" - never use it as a literal tag. Verify tagging coverage with:
 Invoke-Pester -Path ./Tests -TagFilter 'None'   # should find zero tests
 ```
 
+### Testing Private Functions
+
+A module built to these standards exports only what `FunctionsToExport` names, so private functions
+are unreachable from a test file. Use `InModuleScope` to run assertions inside the module's scope,
+where internal functions and classes are visible:
+
+```powershell
+It 'Returns a session for the target environment' {
+    InModuleScope MyModule {
+        $session = Connect-Service -Environment 'Test' -CorrelationId ([guid]::NewGuid())
+        $session.Environment | Should-Be 'Test'
+    }
+}
+```
+
+`InModuleScope` is also how you mock a private function that a public one calls, and how you reach a
+class defined in `Classes/`:
+
+```powershell
+InModuleScope MyModule {
+    Mock Get-ServiceStatus { throw 'unreachable' }
+    'A', 'B' | Get-Data -ErrorAction SilentlyContinue | Should-BeFalsy
+}
+```
+
+Do not export a function purely to make it testable - that widens the public contract to serve the
+tests. Reach into the module instead.
+
+### Worked Examples
+
+These are complete, passing implementations of the patterns above. Prefer matching them over
+inventing a structure:
+
+- [Module-Structure-Example/Tests](../../Documentation/Examples/Module-Structure-Example/Tests/) -
+  module contract, class assertions, `InModuleScope` for two private functions, and a per-item
+  failure path
+- [Testing-Examples/Basic-Function.Tests.ps1](../../Documentation/Examples/Testing-Examples/Basic-Function.Tests.ps1) -
+  CIM mocking, `-RemoveParameterType`, `-TestCases`, and mock scoping across contexts
+- [Tools/Tests](../../Tools/Tests/) - tests for the repository's own tooling, including fixture
+  files written per test and error-path coverage
+
 ### Documentation Integration
 
 All test implementations must reference:

--- a/.github/instructions/style-enforcement.instructions.md
+++ b/.github/instructions/style-enforcement.instructions.md
@@ -20,6 +20,18 @@ Automatically enforce PowerShell community style guidelines in all code generati
 - **Line Length**: Maximum 115 characters
 - **Blank Lines**: 2 blank lines before functions, 1 between methods
 
+A team that wants these checked mechanically does not need a settings file - PSScriptAnalyzer ships
+`CodeFormattingOTBS`, which already configures the brace style, 4-space indentation, whitespace and
+assignment alignment above:
+
+```powershell
+Invoke-ScriptAnalyzer -Path . -Recurse -Settings CodeFormattingOTBS
+```
+
+The 115-character limit is the one rule it does not include; add `PSAvoidLongLines` if the team
+wants it enforced. Adopting either is their choice - these standards describe the practices, not the
+audit configuration.
+
 ### Parameter Formatting
 
 ```powershell

--- a/.github/instructions/style-enforcement.instructions.md
+++ b/.github/instructions/style-enforcement.instructions.md
@@ -7,6 +7,10 @@ description: 'Automatic style guide enforcement'
 
 Automatically enforce PowerShell community style guidelines in all code generation.
 
+> **Worked example**: every file under
+> [Documentation/Examples](../../Documentation/Examples/) is written to these rules and passes the
+> repository's own quality gates. When the wording here is ambiguous, match the examples.
+
 ## Mandatory Style Patterns
 
 ### Code Formatting

--- a/Documentation/Examples/Module-Structure-Example/Tests/ModuleExample.Tests.ps1
+++ b/Documentation/Examples/Module-Structure-Example/Tests/ModuleExample.Tests.ps1
@@ -153,20 +153,16 @@ Describe 'ModuleExample' -Tag 'Unit', 'Example' {
         It 'Fails loudly when a source file cannot be dot-sourced' {
             # The loader throws rather than warning: a module that half-loads is
             # worse than one that refuses to.
-            $broken = Join-Path ([System.IO.Path]::GetTempPath()) "mse-$([guid]::NewGuid().ToString('N'))"
-            New-Item -Path (Join-Path $broken 'Public') -ItemType Directory -Force | Out-Null
-            New-Item -Path (Join-Path $broken 'Private') -ItemType Directory -Force | Out-Null
-            New-Item -Path (Join-Path $broken 'Classes') -ItemType Directory -Force | Out-Null
+            # Built under $TestDrive so Pester disposes of it - see test-data-guide.md
+            $broken = Join-Path $TestDrive "mse-$([guid]::NewGuid().ToString('N'))"
+            foreach ($folder in 'Public', 'Private', 'Classes') {
+                New-Item -Path (Join-Path $broken $folder) -ItemType Directory -Force | Out-Null
+            }
             Copy-Item (Join-Path $PSScriptRoot '..' 'ModuleExample.psm1') $broken
             Set-Content -Path (Join-Path $broken 'Public\Broken.ps1') -Value 'function Get-Broken { this is not powershell {'
 
-            try {
-                { Import-Module (Join-Path $broken 'ModuleExample.psm1') -Force -ErrorAction Stop } |
-                    Should-Throw -ExceptionMessage '*Failed to load public function*'
-            }
-            finally {
-                Remove-Item $broken -Recurse -Force -ErrorAction SilentlyContinue
-            }
+            { Import-Module (Join-Path $broken 'ModuleExample.psm1') -Force -ErrorAction Stop } |
+                Should-Throw -ExceptionMessage '*Failed to load public function*'
         }
     }
 

--- a/Documentation/Examples/Test-QualityGates.ps1
+++ b/Documentation/Examples/Test-QualityGates.ps1
@@ -1,5 +1,23 @@
-# Test-QualityGates.ps1 - Example function with FIXED security issues
-# This file demonstrates what the quality gates will catch and fix (security issues resolved)
+# =============================================================================
+# DO NOT USE THIS FILE AS A MODEL. IT DELIBERATELY VIOLATES THE STANDARDS.
+#
+# It exists so the quality gates have something to catch. Running
+# Tools/Test-StandardsCompliance.ps1 against it reports UseApprovedVerbs,
+# AvoidPSCustomObjectOutputType and UseDollarUnderscoreInCatch, which is the
+# point. Both CI workflows exclude it from production analysis by name.
+#
+# Violations present on purpose: Write-Host instead of Write-Verbose, $Error[0]
+# in catch blocks instead of $_, a non-approved verb (Process-TestData), array
+# appending in a loop, string concatenation in a loop, a redundant
+# ValidateNotNullOrEmpty on a mandatory parameter, an unused parameter, and
+# [OutputType([PSCustomObject])].
+#
+# For code to copy, see Basic-Function-Example.ps1 or Module-Structure-Example/.
+#
+# Security issues specifically were resolved - plaintext credentials and string
+# interpolated SQL are gone - so this file is safe to keep in the repository.
+# The quality issues above remain intentionally.
+# =============================================================================
 
 function Test-QualityGates {
     <#

--- a/Tools/Tests/Install-CopilotStandards.Tests.ps1
+++ b/Tools/Tests/Install-CopilotStandards.Tests.ps1
@@ -7,16 +7,14 @@ BeforeAll {
 Describe 'Install-CopilotStandards' -Tag 'Unit', 'Tools' {
 
     BeforeEach {
-        # A fresh throwaway project directory per test - the script writes to disk,
-        # so tests must never share one.
-        $script:ProjectPath = Join-Path ([System.IO.Path]::GetTempPath()) "ics-$([System.Guid]::NewGuid().ToString('N'))"
+        # A fresh project directory per test - the script writes to disk, so tests
+        # must never share one. Sited under $TestDrive, which Pester creates and
+        # removes per container and keeps isolated between files even under
+        # parallel, so no AfterEach cleanup is needed. $TestDrive is a real
+        # filesystem path, unlike the TestDrive: PSDrive, so it works with the
+        # native and .NET calls this script makes.
+        $script:ProjectPath = Join-Path $TestDrive "ics-$([System.Guid]::NewGuid().ToString('N'))"
         New-Item -Path $script:ProjectPath -ItemType Directory -Force | Out-Null
-    }
-
-    AfterEach {
-        if (Test-Path $script:ProjectPath) {
-            Remove-Item $script:ProjectPath -Recurse -Force -ErrorAction SilentlyContinue
-        }
     }
 
     Context 'Parameter validation' {

--- a/Tools/Tests/Test-StandardsCompliance.Tests.ps1
+++ b/Tools/Tests/Test-StandardsCompliance.Tests.ps1
@@ -21,14 +21,9 @@ BeforeAll {
 Describe 'Test-StandardsCompliance' -Tag 'Unit', 'Tools' {
 
     BeforeEach {
-        $script:FixturePath = Join-Path ([System.IO.Path]::GetTempPath()) "tsc-$([System.Guid]::NewGuid().ToString('N'))"
+        # Under $TestDrive, which Pester removes per container - see test-data-guide.md.
+        $script:FixturePath = Join-Path $TestDrive "tsc-$([System.Guid]::NewGuid().ToString('N'))"
         New-Item -Path $script:FixturePath -ItemType Directory -Force | Out-Null
-    }
-
-    AfterEach {
-        if (Test-Path $script:FixturePath) {
-            Remove-Item $script:FixturePath -Recurse -Force -ErrorAction SilentlyContinue
-        }
     }
 
     Context 'Parameter validation' {
@@ -423,20 +418,17 @@ function Get-Clean {
         It 'Does not exclude everything when the project path contains "test"' {
             # Regression: the filter tested $_.FullName, so a project under
             # C:\testing\... excluded every file and still reported success.
-            $pathWithTest = Join-Path ([System.IO.Path]::GetTempPath()) "testing-$([guid]::NewGuid().ToString('N'))"
+            # The directory name must contain "test" for this regression to bite
+            $pathWithTest = Join-Path $TestDrive "testing-$([guid]::NewGuid().ToString('N'))"
             New-Item -Path $pathWithTest -ItemType Directory -Force | Out-Null
-            try {
-                Set-Content (Join-Path $pathWithTest 'Get-Real.ps1') 'function Get-Real { param([Parameter(Mandatory)][string]$N) $N }'
-                Set-Content (Join-Path $pathWithTest 'Thing.Tests.ps1') 'Describe "x" { It "y" { $true } }'
 
-                $result = & $script:ScriptPath -Path $pathWithTest -ExcludeTests -PassThru `
-                    -InformationAction SilentlyContinue -WarningAction SilentlyContinue
+            Set-Content (Join-Path $pathWithTest 'Get-Real.ps1') 'function Get-Real { param([Parameter(Mandatory)][string]$N) $N }'
+            Set-Content (Join-Path $pathWithTest 'Thing.Tests.ps1') 'Describe "x" { It "y" { $true } }'
 
-                $result.TotalFiles | Should-Be 1
-            }
-            finally {
-                Remove-Item $pathWithTest -Recurse -Force -ErrorAction SilentlyContinue
-            }
+            $result = & $script:ScriptPath -Path $pathWithTest -ExcludeTests -PassThru `
+                -InformationAction SilentlyContinue -WarningAction SilentlyContinue
+
+            $result.TotalFiles | Should-Be 1
         }
 
         It 'Skips test files when -ExcludeTests is supplied' {


### PR DESCRIPTION
The examples and templates exist so the instruction files can point Copilot at them. They did not.

## The gap

Before this change the entire `.github` tree contained **one** markdown link into
`Documentation/Examples` — a "Related Documentation" bullet added in #17 while repairing broken
links — and **no prose anywhere** telling Copilot to consult an example: no "see the example", no
"follow the pattern in", no "reference implementation".

Every `ModuleName.psd1` occurrence in the instructions is a placeholder inside a code sample, not a
pointer to `Templates/Powershell-Module/`.

This matters mechanically. Instruction files reach Copilot through their `applyTo` globs.
`Documentation/Examples/` and `Templates/` reach it only when someone is editing those files, which
is backwards. As reference material the instructions could cite, the examples were unreachable, and
the work invested in them carried no weight in the system they exist to serve.

## Now cited from the instruction that describes each pattern

| Instruction | Points at |
|---|---|
| `module.instructions.md` | `Module-Structure-Example` from the layout, manifest and loader sections |
| `pester.instructions.md` | A **Worked Examples** section covering all three test suites |
| `mocking-patterns.md` | Mocking a function a module calls internally |
| `unit-test-template.md` | Passing implementations of the template |
| `comments.instructions.md` | A complete help block |
| `errorsandlogs.instructions.md` | Correlation IDs and per-item failure handling |
| `style-enforcement.instructions.md` | Match the examples where wording is ambiguous |
| `copilot-instructions.md` | A need-to-example table |

References went from 1 to 18 across 8 files.

`copilot-instructions.md` also now states explicitly that `Test-QualityGates.ps1` intentionally
violates the standards and is never a model — previously nothing distinguished it from the examples
that are.

## `InModuleScope`

Absent from all twelve Pester documents. The repository teaches Public/Private structure with
manifest-controlled export as its central module lesson, then gave no way to test the private half —
`test-structure-guide.md` tells authors to group private-function tests without ever saying how to
reach one.

Added to `pester.instructions.md` and `mocking-patterns.md`, including the rule that a function
should not be exported merely to make it testable. Both point at the ten uses in
`Module-Structure-Example/Tests`, so the guidance and a passing implementation stay in step.

## Also fixed

`module.instructions.md` declared `#Requires -Version 5.1` in the root module template while the
manifest twenty lines earlier declared `PowerShellVersion = '7.6'`.

## Verification

124 tests, 0 analyzer errors or warnings, coverage 93.23%, markdownlint clean, and every new link
verified to resolve. The remaining unresolved paths are the sample-README content established in #15
as correct in their destination context.

---

## Also: analyzer presets, not a settings file

`style-enforcement.instructions.md` defines One True Brace Style, 4-space indentation and spacing
rules but pointed at no way to check them, and the CI examples in `cicd.instructions.md` used
`-Settings PSGallery`, a preset encoding none of them.

The gap needed no new file. PSScriptAnalyzer 1.25.0 ships ten presets, and `CodeFormattingOTBS`
already configures exactly those rules — `PSPlaceOpenBrace` with `OnSameLine`,
`PSUseConsistentIndentation` at 4, `PSUseConsistentWhitespace`, `PSAlignAssignmentStatement` and
`PSUseCorrectCasing`.

Both files now name it, and both state that adopting a preset is the consuming team's decision.
These standards describe practices for Copilot to follow at generation time; they do not prescribe
what a team audits. The 115-character limit is the one documented rule no preset covers, so
`PSAvoidLongLines` is named as an explicit addition.

Verified rather than asserted: run against deliberately mis-formatted code, `CodeFormattingOTBS`
fires `PSPlaceOpenBrace`, `PSUseConsistentIndentation` and `PSUseConsistentWhitespace`, and
`PSAvoidLongLines` resolves as a real rule.

## Also: TestDrive, and the anti-pattern file's header

`test-data-guide.md` says to use `TestDrive` rather than `$env:TEMP`, because Pester creates and
removes it per container and keeps it isolated between files even under parallel. Every test file
ignored that, including those added in #18 and #19. All eight sites now use `$TestDrive`, and the
`AfterEach` cleanup and `try`/`finally` wrappers are gone with it — `$TestDrive` rather than the
`TestDrive:` PSDrive, because these tests hand paths to PSScriptAnalyzer, `Import-Module` and a
script calling native tools.

`Test-QualityGates.ps1` opened with "Example function with **FIXED** security issues", which reads
as a corrected example — the opposite of what it is, and a live hazard now that the instructions
point Copilot at that directory. Its header now leads with "DO NOT USE THIS FILE AS A MODEL", lists
the violations present on purpose, and points at the two files that are safe to copy. Verified the
new header does not mask what it documents: the file still trips all three compliance rules.
