### PR TITLE
fix: make the anti-pattern example's tests capable of failing

### DIFF
--- a/Documentation/Examples/Test-QualityGates.Tests.ps1
+++ b/Documentation/Examples/Test-QualityGates.Tests.ps1
@@ -1,10 +1,28 @@
 #Requires -Module Pester
 
 BeforeAll {
-    # Dot-source the file under test
-    $TestFilePath = Join-Path $PSScriptRoot 'Test-QualityGates.ps1'
-    if (Test-Path $TestFilePath) {
-        . $TestFilePath
+    $script:SourcePath = Join-Path $PSScriptRoot 'Test-QualityGates.ps1'
+    . $script:SourcePath
+
+    # Parse once. The file-level checks below inspect the AST rather than raw
+    # text, because this file documents the patterns it violates - a regex for
+    # 'Write-Host' matches the comments describing the violation as readily as
+    # the call itself, and would report inflated counts that never go to zero.
+    $script:Ast = [System.Management.Automation.Language.Parser]::ParseFile(
+        $script:SourcePath, [ref]$null, [ref]$null)
+
+    $script:Functions = $script:Ast.FindAll({
+            param($node)
+            $node -is [System.Management.Automation.Language.FunctionDefinitionAst]
+        }, $true)
+
+    function Get-CallsTo {
+        param([string]$Name)
+        $script:Ast.FindAll({
+                param($node)
+                $node -is [System.Management.Automation.Language.CommandAst] -and
+                $node.GetCommandName() -eq $Name
+            }, $true)
     }
 
     # Test-QualityGates calls Get-ADUser, which ships with RSAT and is absent on CI
@@ -102,21 +120,24 @@ Describe "Test-QualityGates Function" -Tag "Unit", "QualityDemo" {
     }
 }
 
-Describe "Get-TestResults Function" -Tag "Unit", "GoodExample" {
+Describe "Get-TestResult Function" -Tag "Unit", "GoodExample" {
 
     Context "Proper Implementation Validation" {
-        It "Should use approved PowerShell verb" {
-            # Should -BeIn has no 1:1 replacement; Should-Any expresses the same check
-            $approvedVerbs = Get-Verb | Select-Object -ExpandProperty Verb
-            $approvedVerbs | Should-Any { $_ -eq 'Get' }
+        It "Is named with an approved verb and a singular noun" {
+            $verb, $noun = 'Get-TestResult' -split '-', 2
+
+            (Get-Verb).Verb | Should-Any { $_ -eq $verb }
+            # PSUseSingularNouns fires on a trailing 's'. The plural form is what
+            # this function was called before, and it was a real analyzer warning.
+            $noun.EndsWith('s') | Should-BeFalse
         }
 
         It "Should accept mandatory TestName parameter" {
-            Get-TestResults -TestName "SecurityTest"
+            Get-TestResult -TestName "SecurityTest"
         }
 
         It "Should generate correlation ID automatically" {
-            $result = Get-TestResults -TestName "AutoTest"
+            $result = Get-TestResult -TestName "AutoTest"
             $result.CorrelationId | Should-NotBeEmptyString
             $result.CorrelationId |
                 Should-MatchString "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
@@ -125,17 +146,17 @@ Describe "Get-TestResults Function" -Tag "Unit", "GoodExample" {
         It "Should handle empty test name appropriately" {
             # A Mandatory [string] rejects '' during binding, before the body runs,
             # so the message comes from PowerShell - not the function's own guard.
-            { Get-TestResults -TestName "" } | Should-Throw -ExceptionMessage '*empty string*'
+            { Get-TestResult -TestName "" } | Should-Throw -ExceptionMessage '*empty string*'
         }
 
         It "Should handle whitespace-only test name" {
             # Whitespace binds fine, so the function's own validation produces this one
-            { Get-TestResults -TestName "   " } |
+            { Get-TestResult -TestName "   " } |
                 Should-Throw -ExceptionMessage '*cannot be empty or whitespace*'
         }
 
         It "Should return properly typed result" {
-            $result = Get-TestResults -TestName "TypeTest"
+            $result = Get-TestResult -TestName "TypeTest"
             # PSTypeName is consumed when constructing the object; it sets the type
             # name rather than remaining as a readable property.
             $result.PSObject.TypeNames[0] | Should-Be "TestResult"
@@ -143,7 +164,7 @@ Describe "Get-TestResults Function" -Tag "Unit", "GoodExample" {
         }
 
         It "Should include all required properties" {
-            $result = Get-TestResults -TestName "PropertyTest"
+            $result = Get-TestResult -TestName "PropertyTest"
 
             $result.TestName | Should-Be "PropertyTest"
             $result.Status | Should-NotBeEmptyString
@@ -154,14 +175,28 @@ Describe "Get-TestResults Function" -Tag "Unit", "GoodExample" {
 
     Context "Parameter Validation Best Practices" {
         It "Should trim whitespace from TestName parameter" {
-            $result = Get-TestResults -TestName "  TrimTest  "
+            $result = Get-TestResult -TestName "  TrimTest  "
             $result.TestName | Should-Be "TrimTest"
         }
 
         It "Should accept custom correlation ID" {
             $customId = [System.Guid]::NewGuid().ToString()
-            $result = Get-TestResults -TestName "CustomIdTest" -CorrelationId $customId
+            $result = Get-TestResult -TestName "CustomIdTest" -CorrelationId $customId
             $result.CorrelationId | Should-Be $customId
+        }
+    }
+
+    Context "Analyzer Cleanliness" {
+        It "Produces no analyzer warnings or errors, as the file header claims" {
+            # The function is documented as the compliant contrast. Before this test
+            # existed it carried two warnings - an unused $errorDetails hashtable and
+            # a plural noun - so the claim was false and nothing caught it.
+            $start = ($script:Functions | Where-Object { $_.Name -eq 'Get-TestResult' }).Extent.StartLineNumber
+
+            $findings = Invoke-ScriptAnalyzer -Path $script:SourcePath -Severity Warning, Error |
+                Where-Object { $_.Line -ge $start }
+
+            ($findings | ForEach-Object { "$($_.RuleName) L$($_.Line)" }) -join '; ' | Should-Be ''
         }
     }
 }
@@ -169,10 +204,9 @@ Describe "Get-TestResults Function" -Tag "Unit", "GoodExample" {
 Describe "Process-TestData Function" -Tag "Unit", "QualityIssue" {
 
     Context "Verb Validation" {
-        It "Should use non-approved verb (demonstrates quality issue)" {
-            # This test documents the quality issue for educational purposes
-            $approvedVerbs = Get-Verb | Select-Object -ExpandProperty Verb
-            $approvedVerbs | Should-All { $_ -ne 'Process' }
+        It "Uses a verb PowerShell does not approve, which is the demonstration" {
+            $verb = ('Process-TestData' -split '-', 2)[0]
+            (Get-Verb).Verb | Should-All { $_ -ne $verb }
         }
     }
 
@@ -184,63 +218,91 @@ Describe "Process-TestData Function" -Tag "Unit", "QualityIssue" {
     }
 }
 
-Describe "Quality Standards Compliance" -Tag "Integration", "QualityCheck" {
+Describe "Deliberate Violations Stay Pinned" -Tag "Integration", "QualityCheck" {
+
+    # These lock the file's stated violations to what it actually contains. The
+    # header lists them, Tools/Test-StandardsCompliance.ps1 is expected to catch
+    # them, and both CI workflows exclude the file on that basis. If someone
+    # cleans one up, these fail and force the header and the exclusion to be
+    # revisited rather than silently drifting out of date.
 
     Context "PowerShell Best Practices" {
-        It "Should use Write-Verbose instead of Write-Host in functions" {
-            # This test would check for Write-Host usage (quality issue in Test-QualityGates)
-            $testFile = Get-Content -Path (Join-Path $PSScriptRoot 'Test-QualityGates.ps1') -Raw
+        It "Keeps exactly the two Write-Host calls the header describes" {
+            $calls = Get-CallsTo -Name 'Write-Host'
 
-            # Count Write-Host occurrences (should be minimal in production code)
-            $writeHostCount = ([regex]::Matches($testFile, 'Write-Host', 'IgnoreCase')).Count
-
-            # Document the quality issue
-            if ($writeHostCount -gt 0) {
-                Write-Warning "Found $writeHostCount instances of Write-Host in test file (quality issue for demonstration)"
+            $calls.Count | Should-Be 2
+            # Both belong to the non-compliant function, not the compliant one
+            $goodStart = ($script:Functions | Where-Object { $_.Name -eq 'Get-TestResult' }).Extent.StartLineNumber
+            foreach ($call in $calls) {
+                $call.Extent.StartLineNumber | Should-BeLessThan $goodStart
             }
         }
 
-        It "Should use approved PowerShell verbs in all functions" {
-            $testFile = Get-Content -Path (Join-Path $PSScriptRoot 'Test-QualityGates.ps1') -Raw
-            $approvedVerbs = Get-Verb | Select-Object -ExpandProperty Verb
+        It "Keeps Process-TestData as the only non-approved verb in the file" {
+            $approvedVerbs = (Get-Verb).Verb
+            $nonApproved = $script:Functions.Name |
+                Where-Object { ($_ -split '-', 2)[0] -notin $approvedVerbs }
 
-            # Find function definitions
-            $functionMatches = [regex]::Matches($testFile, 'function\s+([A-Za-z]+)-([A-Za-z0-9]+)', 'IgnoreCase')
+            ($nonApproved -join ', ') | Should-Be 'Process-TestData'
+        }
 
-            $verbIssues = @()
-            foreach ($match in $functionMatches) {
-                $verb = $match.Groups[1].Value
-                if ($verb -notin $approvedVerbs) {
-                    $verbIssues += $verb
-                }
-            }
+        It 'Keeps the $Error[0] catch block that UseDollarUnderscoreInCatch reports' {
+            $indexed = $script:Ast.FindAll({
+                    param($node)
+                    $node -is [System.Management.Automation.Language.IndexExpressionAst] -and
+                    $node.Target.VariablePath.UserPath -eq 'Error'
+                }, $true)
 
-            if ($verbIssues.Count -gt 0) {
-                Write-Warning "Found non-approved verbs: $($verbIssues -join ', ') (quality issues for demonstration)"
+            $indexed.Count | Should-Be 1
+        }
+    }
+
+    Context "The Compliance Checker" {
+        It "Reports the three rules the file header says it reports" {
+            # This is the file's reason for existing, and the basis on which both
+            # CI workflows exclude it from production analysis. The Tools suite
+            # proves each rule fires against a synthetic fixture; nothing proved
+            # it fires against the file the header points at.
+            $checker = Join-Path $PSScriptRoot '..' '..' 'Tools' 'Test-StandardsCompliance.ps1' | Resolve-Path
+
+            $result = & $checker -Path $script:SourcePath -PassThru 6>$null
+
+            foreach ($rule in 'UseApprovedVerbs', 'AvoidPSCustomObjectOutputType', 'UseDollarUnderscoreInCatch') {
+                $result.ComplianceIssues.RuleName | Should-ContainCollection $rule
             }
         }
     }
 
     Context "Security Best Practices" {
-        It "Should not contain hardcoded passwords" {
-            $testFile = Get-Content -Path (Join-Path $PSScriptRoot 'Test-QualityGates.ps1') -Raw
+        It "Contains no hardcoded passwords" {
+            # Unlike the checks above this is not a pinned violation - security
+            # issues were removed from this file deliberately, and must stay out.
+            $content = Get-Content -Path $script:SourcePath -Raw
 
-            # Check for common password patterns
             $passwordPatterns = @(
                 'password\s*[:=]\s*["\x27]\w{3,}["\x27]',
                 '\$\w*[Pp]assword\w*\s*=\s*["\x27]\w+["\x27]'
             )
 
-            $securityIssues = @()
-            foreach ($pattern in $passwordPatterns) {
-                if ($testFile -match $pattern) {
-                    $securityIssues += "Hardcoded password pattern found"
-                }
-            }
+            $found = $passwordPatterns | Where-Object { $content -match $_ }
 
-            if ($securityIssues.Count -gt 0) {
-                Write-Warning "Security issues found: $($securityIssues -join ', ') (quality issues for demonstration)"
-            }
+            ($found -join '; ') | Should-Be ''
+        }
+
+        It "Contains no interpolated SQL" {
+            $content = Get-Content -Path $script:SourcePath -Raw
+            $content | Should-NotMatchString 'SELECT .*\$\w+'
+        }
+    }
+
+    Context "File Encoding" {
+        It "Is pure ASCII, so PSUseBOMForUnicodeEncodedFile stays quiet" {
+            # The file previously used checkmark emoji in its comments, which made
+            # it non-ASCII without a BOM and tripped the rule.
+            $content = [System.IO.File]::ReadAllText($script:SourcePath)
+            $nonAscii = [regex]::Matches($content, '[^\x00-\x7F]')
+
+            $nonAscii.Count | Should-Be 0
         }
     }
 }

--- a/Documentation/Examples/Test-QualityGates.ps1
+++ b/Documentation/Examples/Test-QualityGates.ps1
@@ -1,35 +1,38 @@
 # =============================================================================
-# DO NOT USE THIS FILE AS A MODEL. IT DELIBERATELY VIOLATES THE STANDARDS.
+# DO NOT COPY FROM THIS FILE WITHOUT READING THIS HEADER.
 #
-# It exists so the quality gates have something to catch. Running
-# Tools/Test-StandardsCompliance.ps1 against it reports UseApprovedVerbs,
+# Test-QualityGates and Process-TestData DELIBERATELY VIOLATE THE STANDARDS.
+# They exist so the quality gates have something to catch. Running
+# Tools/Test-StandardsCompliance.ps1 against this file reports UseApprovedVerbs,
 # AvoidPSCustomObjectOutputType and UseDollarUnderscoreInCatch, which is the
 # point. Both CI workflows exclude it from production analysis by name.
 #
-# Violations present on purpose: Write-Host instead of Write-Verbose, $Error[0]
-# in catch blocks instead of $_, a non-approved verb (Process-TestData), array
-# appending in a loop, string concatenation in a loop, a redundant
-# ValidateNotNullOrEmpty on a mandatory parameter, an unused parameter, and
-# [OutputType([PSCustomObject])].
+# Violations present on purpose, all of them in those two functions: Write-Host
+# instead of Write-Verbose, $Error[0] in catch blocks instead of $_, a
+# non-approved verb (Process-TestData), array appending in a loop, string
+# concatenation in a loop, a redundant ValidateNotNullOrEmpty on a mandatory
+# parameter, an unused parameter, and [OutputType([PSCustomObject])].
 #
-# For code to copy, see Basic-Function-Example.ps1 or Module-Structure-Example/.
+# Get-TestResult, at the bottom, is the one compliant function in the file and
+# is here as the contrast. It passes PSScriptAnalyzer clean. For fuller models
+# see Basic-Function-Example.ps1 or Module-Structure-Example/.
 #
-# Security issues specifically were resolved - plaintext credentials and string
-# interpolated SQL are gone - so this file is safe to keep in the repository.
-# The quality issues above remain intentionally.
+# Security issues are NOT among the deliberate violations - plaintext
+# credentials and interpolated SQL were removed, so this file is safe to keep in
+# the repository. The spots where that matters are marked "Not a violation".
 # =============================================================================
 
 function Test-QualityGates {
     <#
     .SYNOPSIS
-    Test function to demonstrate quality gate enforcement
+    Deliberately non-compliant function used to prove the quality gates fire.
 
     .DESCRIPTION
-    This function intentionally contains several quality issues that should be
-    caught by the PowerShell quality gates, including parameter validation issues,
-    performance anti-patterns, but with security issues RESOLVED.
+    Contains quality violations on purpose - see the file header for the list.
+    Not a model. Security issues specifically are absent, so the file is safe to
+    keep in the repository.
 
-    .PARAMETER UserName  
+    .PARAMETER UserName
     The username to process
 
     .PARAMETER ServerList
@@ -41,79 +44,79 @@ function Test-QualityGates {
     .PARAMETER DatabaseCredential
     Secure credential for database access
 
+    .PARAMETER UnusedParameter
+    Declared and never referenced - one of the deliberate violations
+
     .EXAMPLE
     $cred = Get-Credential
     Test-QualityGates -UserName "testuser" -ServerList @("server1", "server2") -DatabaseCredential $cred
-    
-    Demonstrates basic usage with security issues resolved.
+
+    Demonstrates the call shape. The quality violations are in the body.
 
     .NOTES
-    Author: Jeffrey Stuhr
     Purpose: Quality gate testing and demonstration
     #>
     [CmdletBinding()]
-    [OutputType([PSCustomObject])]  # This should be descriptive type name
+    [OutputType([PSCustomObject])]  # Violation: should be a descriptive type name
     param(
         [Parameter(Mandatory = $true)]
-        [ValidateNotNullOrEmpty()]  # Expert feedback: redundant on mandatory params
+        [ValidateNotNullOrEmpty()]  # Violation: redundant on a mandatory parameter
         [string]$UserName,
-        
+
         [Parameter()]
         [string[]]$ServerList,
-        
+
         [Parameter()]
         [object[]]$ProcessData,
-        
+
         [Parameter()]
-        [PSCredential]$DatabaseCredential,  # ✅ FIXED: Use PSCredential instead of plain text
-        
+        [PSCredential]$DatabaseCredential,  # Not a violation: PSCredential, not plain text
+
         [Parameter()]
-        [string]$UnusedParameter  # Quality issue: unused parameter (kept for demonstration)
+        [string]$UnusedParameter  # Violation: declared and never referenced
     )
-    
+
     begin {
-        Write-Host "Starting quality gate test..." -ForegroundColor Green  # Issue: using Write-Host
-        
-        # Performance issue: building arrays in loops
+        Write-Host "Starting quality gate test..." -ForegroundColor Green  # Violation: Write-Host
+
+        # Violation: array built by appending in the loop below
         $results = @()
-        
-        # ✅ FIXED: Use secure credential handling
+
+        # Not a violation: the credential is never expanded to plain text
         if ($DatabaseCredential) {
             Write-Verbose "Database credential provided securely"
         } else {
             Write-Verbose "No database credential provided"
         }
     }
-    
+
     process {
         try {
-            # Issue: using $Error[0] instead of $_ (expert feedback)
             Write-Verbose "Processing user: $UserName"
-            
-            # Parameter validation issue: not checking before downstream usage
-            $userInfo = Get-ADUser -Identity $UserName  # Could fail if UserName is empty
-            
-            # Performance anti-pattern: array appending in loop
+
+            # Violation: result used downstream without being checked first
+            $userInfo = Get-ADUser -Identity $UserName
+
+            # Violation: array appending in a loop reallocates on every pass
             foreach ($server in $ServerList) {
-                $results += "Processing $server"  # Creates new array each time
+                $results += "Processing $server"
             }
-            
-            # String concatenation issue: should use StringBuilder for large operations
+
+            # Violation: string concatenation in a loop - StringBuilder belongs here
             $logOutput = ""
             for ($i = 0; $i -lt 1000; $i++) {
-                $logOutput += "Log entry $i`n"  # Inefficient for large operations
+                $logOutput += "Log entry $i`n"
             }
-            
-            # ✅ FIXED: Use parameterized queries instead of string interpolation
-            $query = "SELECT * FROM Users WHERE Name = @UserName"  # Parameterized query
+
+            # Not a violation: parameterized query, not string interpolation
+            $query = "SELECT * FROM Users WHERE Name = @UserName"
             $queryParams = @{ UserName = $UserName }
-            
-            # Issue: throw that can be silenced (expert feedback Part 2)
+
+            # Violation: a bare throw here can be silenced by -ErrorAction SilentlyContinue
             if (-not $userInfo) {
-                throw "User not found: $UserName"  # Can be silenced with -ErrorAction SilentlyContinue
+                throw "User not found: $UserName"
             }
-            
-            # Create result with quality issues (but security fixed)
+
             $result = [PSCustomObject]@{
                 UserName = $UserName
                 ServersProcessed = $results.Count
@@ -123,50 +126,56 @@ function Test-QualityGates {
                 HasDatabaseCredential = [bool]$DatabaseCredential
                 ProcessedAt = Get-Date
             }
-            
+
             return $result
         }
         catch {
-            # Issue: using $Error[0] instead of $_ (expert feedback Part 1)
-            $currentError = $Error[0]  # Should use $_ in catch blocks
+            # Violation: $Error[0] instead of $_ - $Error is global and mutable, so
+            # this can report an unrelated error
+            $currentError = $Error[0]
             Write-Error "Processing failed: $($currentError.Exception.Message)"
             throw
         }
     }
-    
+
     end {
-        Write-Host "Quality gate test completed" -ForegroundColor Yellow  # Issue: Write-Host again
+        Write-Host "Quality gate test completed" -ForegroundColor Yellow  # Violation: Write-Host
     }
 }
 
-# Additional function with non-approved verb (quality issue)
-function Process-TestData {  # Issue: "Process" is not an approved PowerShell verb
+
+# Violation: "Process" is not an approved PowerShell verb - see Get-Verb
+function Process-TestData {
     param(
         [string]$Data
     )
-    
-    # Simple processing
+
     return "Processed: $Data"
 }
 
-# Function with correct patterns for comparison
-function Get-TestResults {
+
+function Get-TestResult {
     <#
     .SYNOPSIS
-    Correctly implemented function following all standards
-    
+    The compliant contrast to the two functions above.
+
     .DESCRIPTION
-    This function demonstrates proper PowerShell patterns that should pass
-    all quality gates without issues.
-    
+    Demonstrates the patterns the standards ask for: an approved verb with a
+    singular noun, a mandatory parameter without a redundant validator,
+    correlation ID tracking, $_ in the catch block, and a PSTypeName-stamped
+    output object. Passes PSScriptAnalyzer clean.
+
     .PARAMETER TestName
     Name of the test to run
-    
+
+    .PARAMETER CorrelationId
+    Correlation ID for tracing; generated when not supplied
+
     .EXAMPLE
-    Get-TestResults -TestName "SecurityTest"
-    
-    Runs the specified test and returns results.
-    
+    Get-TestResult -TestName "SecurityTest"
+
+    Runs the specified test and returns the result.
+
     .OUTPUTS
     TestResult. Returns test execution results.
     #>
@@ -177,24 +186,24 @@ function Get-TestResults {
     param(
         [Parameter(Mandatory)]  # No redundant ValidateNotNullOrEmpty
         [string]$TestName,
-        
+
         [Parameter()]
         [string]$CorrelationId = [System.Guid]::NewGuid().ToString()
     )
-    
+
     begin {
         Write-Verbose "Starting test: $TestName - CorrelationId: $CorrelationId"
     }
-    
+
     process {
         try {
-            # Proper parameter validation before downstream usage
+            # Validate before downstream use. Mandatory rejects '' at binding time,
+            # but whitespace binds fine and still has to be caught.
             if (-not $TestName.Trim()) {
                 Write-Error "TestName cannot be empty or whitespace" -ErrorAction Stop
                 return
             }
-            
-            # Simulate test execution
+
             $testResult = [PSCustomObject]@{
                 PSTypeName = 'TestResult'
                 TestName = $TestName.Trim()
@@ -202,22 +211,24 @@ function Get-TestResults {
                 CorrelationId = $CorrelationId
                 ExecutedAt = Get-Date
             }
-            
+
             Write-Output $testResult
         }
         catch {
-            # Correct error handling using $_ (expert feedback)
+            # Correct: $_ in the catch block, and the structured detail is emitted
+            # rather than assembled and dropped
             $errorDetails = @{
                 TestName = $TestName
                 ErrorMessage = $_.Exception.Message
                 CorrelationId = $CorrelationId
             }
-            
-            Write-Verbose "Test failed: $TestName - Error: $($_.Exception.Message)"
+
+            Write-Verbose ("Test failed: {0} - Error: {1} - CorrelationId: {2}" -f
+                $errorDetails.TestName, $errorDetails.ErrorMessage, $errorDetails.CorrelationId)
             Write-Error "Test execution failed: $($_.Exception.Message)" -ErrorAction Stop
         }
     }
-    
+
     end {
         Write-Verbose "Test completed: $TestName - CorrelationId: $CorrelationId"
     }


### PR DESCRIPTION
Five tests in this file asserted nothing. They ran, printed warnings, and passed
regardless of input.

## The tests that could not fail

Three ended without an assertion:

```powershell
$writeHostCount = ([regex]::Matches($testFile, 'Write-Host', 'IgnoreCase')).Count
if ($writeHostCount -gt 0) {
    Write-Warning "Found $writeHostCount instances of Write-Host (quality issue for demonstration)"
}
```

The other two asserted against PowerShell's verb list rather than the code under
test — `$approvedVerbs | Should-Any { $_ -eq 'Get' }` passes whether or not
`Get-TestResults` exists, and `Should-All { $_ -ne 'Process' }` is a property of
`Get-Verb` that no change to `Process-TestData` could affect.

This is the defect #19 fixed in the workflow, in the file the workflow points at:
something shaped like verification that verifies nothing.

## What they assert now

Each deliberate violation is pinned to what the header claims is present, so
cleaning one up fails the suite and forces the header and the CI exclusions to
be revisited rather than drifting out of date. Both workflows exclude this file
from production analysis on the basis of that header.

| Test | Pins |
|---|---|
| Write-Host count | exactly 2, both outside the compliant function |
| non-approved verbs | exactly `Process-TestData` |
| `$Error[0]` indexing | exactly 1 occurrence |
| compliance checker | reports `UseApprovedVerbs`, `AvoidPSCustomObjectOutputType`, `UseDollarUnderscoreInCatch` |
| encoding | file is pure ASCII |
| hardcoded passwords, interpolated SQL | absent, and must stay absent |

The compliance-checker assertion closes a gap: `Tools/Tests` proves each of those
three rules fires against a synthetic fixture, but nothing proved they fire
against the file the header names.

The file-level checks read the AST instead of the raw text. This file documents
the patterns it violates, so a regex for `Write-Host` matches the comment
describing the violation as readily as the call — the same self-matching problem
found in the security scanner in #11 and in both rule sets in #19.

## The function advertised as correct was not

`Get-TestResults` was documented as "Correctly implemented function following all
standards" and carried two analyzer warnings: `PSUseDeclaredVarsMoreThanAssignments`
for an `$errorDetails` hashtable assembled and never emitted, and
`PSUseSingularNouns` for the plural. Renamed to `Get-TestResult`, and the
structured detail now reaches the verbose stream. A test asserts the function
produces no analyzer findings, which is what the file claims about it.

## The comments contradicted the header

Three lines read `# ✅ FIXED: Use PSCredential instead of plain text` and similar,
which frames the file as a corrected example — the opposite of what it is, and
the hazard #20's header rewrite was meant to remove. A model scanning for patterns
weighs an inline annotation ahead of a comment banner, and #20 pointed Copilot at
this directory.

Reworded to `# Not a violation:`. The checkmarks made the file non-ASCII without a
BOM, so `PSUseBOMForUnicodeEncodedFile` fired on it; the file is now ASCII. The
header no longer opens with a blanket prohibition it then contradicts by
containing a compliant function — it names which functions are which.

## Verification

Each new assertion was mutation-tested: seven single-edit mutations of the source
file, every one caught by the test named for it.

| Mutation | Caught by |
|---|---|
| silence one `Write-Host` | Write-Host count |
| unused variable in `Get-TestResult` | analyzer cleanliness |
| rename `Process-TestData` to an approved verb | non-approved verb set |
| restore a checkmark comment | ASCII encoding |
| hardcode a password | hardcoded passwords |
| replace `$Error[0]` with `$_` | `$Error[0]` indexing |
| pluralise `Get-TestResult` | 10 tests, including analyzer cleanliness |

129 tests, 0 failures, 0 analyzer errors or warnings across 13 production files,
coverage 93.18%. The compliance checker's critical-issue count against this file
is unchanged at 3 — the deliberate violations survive — while incidental noise
drops from 44 total issues to 10, most of it 31 trailing-whitespace findings.

Coverage moves from 93.23% to 93.18%: the rewritten catch block in
`Get-TestResult` emits its structured detail across two lines instead of one, and
no test drives that path.
