### PR TITLE
feat(tools): ship a drift-check workflow consuming projects can install

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ PowerShell-Copilot-Standards/
 │   └── workflows/                       # Quality gates run on every pull request
 ├── Documentation/                       # Reference materials and worked examples
 ├── Templates/                           # Module, script-collection, and application templates
+│   └── Workflows/                       # Workflows to copy into consuming projects
 ├── Tools/                               # Install-CopilotStandards, Test-StandardsCompliance
 ├── Troubleshooting/                     # Organized problem-solving guides
 ├── .markdownlint.json                   # Documentation lint rules enforced in CI
@@ -157,6 +158,21 @@ git submodule add https://github.com/fadwen/PowerShell-Copilot-Standards.git .co
 ```powershell
 ./Tools/Install-CopilotStandards.ps1 -ProjectPath "." -StandardsType "Basic"
 ```
+
+#### Option D: Direct Copy, Kept in Sync (Recommended)
+
+Options A through C copy the instruction files once. They then drift as this repository moves on.
+Adding `-IncludeSyncWorkflow` also installs a weekly job that mirrors the instruction files and
+opens a pull request when they fall behind:
+
+```powershell
+./Tools/Install-CopilotStandards.ps1 -ProjectPath "." -StandardsType "Basic" -IncludeSyncWorkflow
+```
+
+The workflow needs **Settings → Actions → General → Workflow permissions → "Allow GitHub Actions to
+create and approve pull requests"** enabled on the target repository, and it overwrites local edits
+to the mirrored paths. See [Templates/Workflows/](Templates/Workflows/README.md) for both caveats in
+full.
 
 ### 3. Verify Setup
 

--- a/Templates/Workflows/README.md
+++ b/Templates/Workflows/README.md
@@ -1,0 +1,71 @@
+# Workflow Templates
+
+Workflows to copy into a project that consumes these standards. They are templates, not active
+workflows: nothing in this folder runs in the standards repository itself.
+
+## sync-copilot-standards.yml
+
+Keeps a consuming project's Copilot instruction files current. Runs weekly, mirrors the three
+instruction paths from the standards repository, and opens a pull request when they have drifted.
+
+Without it, instruction files are copied once and then quietly rot. A project can sit for months on
+guidance that has since been corrected upstream.
+
+### Install
+
+```powershell
+# Along with the standards themselves
+./Tools/Install-CopilotStandards.ps1 -ProjectPath "C:\YourProject" -IncludeSyncWorkflow
+```
+
+Or copy it by hand to `.github/workflows/sync-copilot-standards.yml` in the target repository.
+
+### Enable the repository setting first
+
+The job needs permission to open pull requests:
+
+**Settings → Actions → General → Workflow permissions →
+"Allow GitHub Actions to create and approve pull requests"**
+
+This is a per-repository setting and it is off by default in many organisations. Without it the job
+runs, detects drift correctly, and then fails at the final step. Enable it before the first run, or
+trigger the workflow manually once to confirm.
+
+### What it touches
+
+| Path | Behaviour |
+| --- | --- |
+| `.github/copilot-instructions.md` | Overwritten from upstream |
+| `.github/instructions/` | Mirrored — upstream deletions are applied |
+| `.github/prompts/` | Mirrored — upstream deletions are applied |
+| `.github/workflows/` | Never touched, including this workflow itself |
+| Everything else | Never touched |
+
+### Mirror, not merge
+
+Local edits to the three mirrored paths are overwritten on the next run. This is deliberate: a copy
+that drifts silently is the problem the workflow exists to solve.
+
+If you need a change to those files, make it upstream in the standards repository. If you need
+project-specific guidance, put it in a file outside the mirrored paths — a scoped
+`*.instructions.md` under a different directory, referenced from your own VS Code settings, survives
+every sync.
+
+### Configuration
+
+| Setting | Default | Notes |
+| --- | --- | --- |
+| `env.STANDARDS_REPO` | `fadwen/Powershell-Copilot-Standards` | The only line to change if you maintain a fork |
+| `schedule.cron` | `0 6 * * 1` (Mondays, 06:00 UTC) | Stagger it if several repositories sync at once |
+| `branch` | `chore/sync-copilot-standards` | Reused and deleted after merge |
+
+The workflow also responds to `workflow_dispatch`, so you can run it on demand from the Actions tab.
+Note that `workflow_dispatch` only appears there once the file is on the default branch.
+
+### Actions it uses
+
+Pinned to majors that declare `node24`, so the workflow does not inherit the Node 20 runtime
+deprecation:
+
+- `actions/checkout@v7`
+- `peter-evans/create-pull-request@v8`

--- a/Templates/Workflows/sync-copilot-standards.yml
+++ b/Templates/Workflows/sync-copilot-standards.yml
@@ -1,0 +1,90 @@
+name: Sync Copilot Standards
+
+# Keeps this repository's Copilot instruction files in sync with the standards
+# repository, and opens a pull request whenever they drift.
+#
+# Copy to .github/workflows/sync-copilot-standards.yml in the consuming project.
+#
+# Before the first run, enable:
+#   Settings -> Actions -> General -> Workflow permissions
+#     -> "Allow GitHub Actions to create and approve pull requests"
+# Without it the job detects drift correctly and then fails at the PR step.
+#
+# Forked the standards repository? Change STANDARDS_REPO below. It is the only
+# line that needs editing.
+
+on:
+  schedule:
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+env:
+  STANDARDS_REPO: fadwen/Powershell-Copilot-Standards
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out this repository
+        uses: actions/checkout@v7
+
+      - name: Check out the standards repository
+        uses: actions/checkout@v7
+        with:
+          repository: ${{ env.STANDARDS_REPO }}
+          path: .standards
+
+      - name: Mirror instruction files
+        run: |
+          set -euo pipefail
+          src=.standards/.github
+
+          cp "$src/copilot-instructions.md" .github/copilot-instructions.md
+
+          # Mirror, not merge: files deleted upstream are deleted here too.
+          # Local edits to these paths are overwritten. Customisations belong
+          # upstream, or in a file outside the three mirrored paths.
+          for dir in instructions prompts; do
+            rm -rf ".github/$dir"
+            cp -r "$src/$dir" ".github/$dir"
+          done
+
+          rm -rf .standards
+
+      - name: Detect drift
+        id: drift
+        run: |
+          # Stage first: a file added upstream is untracked here, and plain
+          # `git diff` would not see it.
+          git add -A .github
+          if git diff --cached --quiet -- .github; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "Instruction files are already up to date."
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            git diff --cached --stat -- .github
+          fi
+
+      - name: Open pull request
+        if: steps.drift.outputs.changed == 'true'
+        uses: peter-evans/create-pull-request@v8
+        with:
+          branch: chore/sync-copilot-standards
+          delete-branch: true
+          commit-message: 'chore: sync Copilot instructions from standards repo'
+          title: 'chore: sync Copilot instructions from standards repo'
+          body: |
+            Automated sync from the PowerShell Copilot Standards repository.
+
+            Covers `.github/copilot-instructions.md`, `.github/instructions/` and
+            `.github/prompts/`. Other workflows in `.github/workflows/` are
+            repo-specific and are not touched by this job.
+
+            Review the diff before merging. Anything intended as a permanent local
+            customisation belongs upstream, or this job will overwrite it again on
+            the next run.

--- a/Tools/Install-CopilotStandards.ps1
+++ b/Tools/Install-CopilotStandards.ps1
@@ -16,6 +16,15 @@
 .PARAMETER LinkType
     How to install: Copy, Symlink, Submodule
 
+.PARAMETER IncludeSyncWorkflow
+    Also installs .github/workflows/sync-copilot-standards.yml, a weekly job that
+    mirrors the instruction files from the standards repository and opens a pull
+    request when they drift. Without it the files are copied once and then rot.
+
+    The target repository needs "Allow GitHub Actions to create and approve pull
+    requests" enabled under Settings > Actions > General. An existing workflow file
+    is never overwritten.
+
 .EXAMPLE
     .\Install-CopilotStandards.ps1 -ProjectPath "C:\Projects\MyModule" -StandardsType "Module"
 
@@ -25,6 +34,11 @@
     .\Install-CopilotStandards.ps1 -ProjectPath "." -StandardsType "Basic" -LinkType "Symlink"
 
     Creates symbolic links to standards in current directory
+
+.EXAMPLE
+    .\Install-CopilotStandards.ps1 -ProjectPath "." -IncludeSyncWorkflow
+
+    Installs the standards and the weekly drift-check workflow that keeps them current
 
 .NOTES
     Author: Jeffrey Stuhr
@@ -53,7 +67,10 @@ param(
 
     [Parameter(HelpMessage = "How to install the standards")]
     [ValidateSet('Copy', 'Symlink', 'Submodule')]
-    [string]$LinkType = 'Copy'
+    [string]$LinkType = 'Copy',
+
+    [Parameter(HelpMessage = "Also install the weekly standards drift-check workflow")]
+    [switch]$IncludeSyncWorkflow
 )
 
 begin {
@@ -134,8 +151,9 @@ process {
                             if (-not $isAdmin) {
                                 Write-Warning "Symbolic links on Windows require Administrator privileges. Falling back to Copy method."
                                 $LinkType = 'Copy'
-                                # Recursively call with Copy method
-                                & $MyInvocation.MyCommand.Path -ProjectPath $ProjectPath -StandardsType $StandardsType -LinkType 'Copy'
+                                # Recursively call with Copy method. IncludeSyncWorkflow has to
+                                # ride along, or the fallback silently drops it.
+                                & $MyInvocation.MyCommand.Path -ProjectPath $ProjectPath -StandardsType $StandardsType -LinkType 'Copy' -IncludeSyncWorkflow:$IncludeSyncWorkflow
                                 return
                             }
                             cmd /c mklink "$destInstructions" "$sourceInstructions" 2>$null
@@ -175,6 +193,31 @@ process {
                         Pop-Location
                     }
                 }
+            }
+        }
+
+        # Install the drift-check workflow
+        if ($IncludeSyncWorkflow) {
+            $workflowSource = Join-Path $StandardsPath "Templates\Workflows\sync-copilot-standards.yml"
+            $workflowDir = Join-Path $githubPath "workflows"
+            $workflowDest = Join-Path $workflowDir "sync-copilot-standards.yml"
+
+            if (-not (Test-Path $workflowSource)) {
+                throw "Sync workflow template not found at '$workflowSource'"
+            }
+
+            if (Test-Path $workflowDest) {
+                # Never clobber a workflow the project has already tuned - schedule,
+                # branch name and STANDARDS_REPO are all meant to be edited locally.
+                Write-Warning "Sync workflow already exists at '$workflowDest' - leaving it unchanged"
+            }
+            elseif ($PSCmdlet.ShouldProcess($workflowDest, "Install sync workflow")) {
+                if (-not (Test-Path $workflowDir)) {
+                    New-Item -Path $workflowDir -ItemType Directory -Force | Out-Null
+                }
+                Copy-Item -Path $workflowSource -Destination $workflowDest
+                Write-Information "Installed the standards sync workflow" -InformationAction Continue
+                Write-Warning "Enable 'Allow GitHub Actions to create and approve pull requests' under Settings > Actions > General, or the workflow will fail at the pull request step"
             }
         }
 

--- a/Tools/Tests/Install-CopilotStandards.Tests.ps1
+++ b/Tools/Tests/Install-CopilotStandards.Tests.ps1
@@ -135,6 +135,85 @@ Describe 'Install-CopilotStandards' -Tag 'Unit', 'Tools' {
             Test-Path (Join-Path $script:ProjectPath 'Public') | Should-BeFalse
             Test-Path (Join-Path $script:ProjectPath '.gitignore') | Should-BeFalse
         }
+
+        It 'Installs no sync workflow when -WhatIf is supplied' {
+            & $script:ScriptPath -ProjectPath $script:ProjectPath -IncludeSyncWorkflow -WhatIf `
+                -InformationAction SilentlyContinue -WarningAction SilentlyContinue
+
+            Test-Path (Join-Path $script:ProjectPath '.github/workflows') | Should-BeFalse
+        }
+    }
+
+    Context 'Sync workflow installation' {
+
+        It 'Installs no workflow by default' {
+            & $script:ScriptPath -ProjectPath $script:ProjectPath -InformationAction SilentlyContinue
+
+            Test-Path (Join-Path $script:ProjectPath '.github/workflows') | Should-BeFalse
+        }
+
+        It 'Installs the workflow when -IncludeSyncWorkflow is supplied' {
+            & $script:ScriptPath -ProjectPath $script:ProjectPath -IncludeSyncWorkflow `
+                -InformationAction SilentlyContinue -WarningAction SilentlyContinue
+
+            Test-Path (Join-Path $script:ProjectPath '.github/workflows/sync-copilot-standards.yml') |
+                Should-BeTrue
+        }
+
+        It 'Installs a workflow that mirrors the three instruction paths' {
+            & $script:ScriptPath -ProjectPath $script:ProjectPath -IncludeSyncWorkflow `
+                -InformationAction SilentlyContinue -WarningAction SilentlyContinue
+
+            $content = Get-Content (Join-Path $script:ProjectPath '.github/workflows/sync-copilot-standards.yml') -Raw
+
+            $content | Should-MatchString 'copilot-instructions\.md'
+            $content | Should-MatchString 'instructions prompts'
+            $content | Should-MatchString 'workflow_dispatch'
+        }
+
+        It 'Installs a workflow free of the deprecated Node 20 action majors' {
+            # actions/checkout below v7 and create-pull-request below v8 declare
+            # node20, which GitHub-hosted runners now warn about.
+            & $script:ScriptPath -ProjectPath $script:ProjectPath -IncludeSyncWorkflow `
+                -InformationAction SilentlyContinue -WarningAction SilentlyContinue
+
+            $content = Get-Content (Join-Path $script:ProjectPath '.github/workflows/sync-copilot-standards.yml') -Raw
+
+            $content | Should-MatchString 'actions/checkout@v7'
+            $content | Should-MatchString 'peter-evans/create-pull-request@v8'
+            $content | Should-NotMatchString 'actions/checkout@v[1-6]\b'
+        }
+
+        It 'Does not overwrite a workflow the project has already tuned' {
+            $workflowDir = Join-Path $script:ProjectPath '.github/workflows'
+            New-Item -Path $workflowDir -ItemType Directory -Force | Out-Null
+            $existing = Join-Path $workflowDir 'sync-copilot-standards.yml'
+            Set-Content -Path $existing -Value '# hand-tuned, keep me'
+
+            & $script:ScriptPath -ProjectPath $script:ProjectPath -IncludeSyncWorkflow `
+                -InformationAction SilentlyContinue -WarningAction SilentlyContinue
+
+            Get-Content $existing -Raw | Should-MatchString 'hand-tuned, keep me'
+        }
+
+        It 'Warns about the pull request permission the workflow needs' {
+            $warnings = & $script:ScriptPath -ProjectPath $script:ProjectPath -IncludeSyncWorkflow `
+                -InformationAction SilentlyContinue 3>&1 | Out-String
+
+            $warnings | Should-MatchString 'approve pull requests'
+        }
+
+        It 'Leaves other workflows in the project alone' {
+            $workflowDir = Join-Path $script:ProjectPath '.github/workflows'
+            New-Item -Path $workflowDir -ItemType Directory -Force | Out-Null
+            $unrelated = Join-Path $workflowDir 'ci.yml'
+            Set-Content -Path $unrelated -Value '# the project''s own CI'
+
+            & $script:ScriptPath -ProjectPath $script:ProjectPath -IncludeSyncWorkflow `
+                -InformationAction SilentlyContinue -WarningAction SilentlyContinue
+
+            Get-Content $unrelated -Raw | Should-MatchString "project's own CI"
+        }
     }
 
     Context 'Symlink installation' {


### PR DESCRIPTION
## Why

Options A through C copy the instruction files once and then let them rot. Two downstream repositories had drifted far enough that prompt files were carrying a second prompt's content appended to the end, and neither had ever received `powershell-version.instructions.md`.

## What

- **`Templates/Workflows/sync-copilot-standards.yml`** — mirrors the three instruction paths from this repository weekly and opens a PR on drift.
- **`-IncludeSyncWorkflow`** on `Install-CopilotStandards.ps1` — installs it alongside the standards.
- **Option D** in the README, and `Templates/Workflows/README.md` for the detail.

## Why the template is not in `.github/workflows/`

Placed there it would execute in this repository and sync it against itself — a permanent no-op burning a scheduled run every week, and confusing to read. It lives under `Templates/` so it ships as scaffolding only.

## Two quiet failure modes the docs call out

- **"Allow GitHub Actions to create and approve pull requests"** is a per-repository setting, off by default in many organisations. Without it the job detects drift correctly and *then* fails at the final step. The installer warns about this at install time.
- **The sync mirrors rather than merges.** Local edits to the three paths are overwritten on the next run. Customisations belong upstream, or in a file outside the mirrored paths.

An existing workflow file is never overwritten — schedule, branch name and `STANDARDS_REPO` are all meant to be tuned locally.

## Also

Fixes the unelevated Symlink fallback, which re-invokes the script and would have silently dropped the new switch.

Actions are pinned to majors declaring `node24` (`actions/checkout@v7`, `peter-evans/create-pull-request@v8`), so consuming projects do not inherit the Node 20 runtime deprecation.

## Verification

- Pester: **27 passed, 0 failed** (was 20 — 7 new cases covering default-off, install, content, node24 pins, non-clobber, the permission warning, and leaving other workflows alone)
- PSScriptAnalyzer clean on the installer
- All added markdown lines under the 120-char MD013 limit (checked by hand; no local markdownlint binary)

Not covered by a test: the unelevated Symlink fallback path, which CI cannot force deterministically.